### PR TITLE
Peng/bonding changes

### DIFF
--- a/app/src/renderer/components/staking/LiDelegate.vue
+++ b/app/src/renderer/components/staking/LiDelegate.vue
@@ -12,7 +12,9 @@
   .li-delegate__value.status
     span {{ delegateType }}
   template(v-if="userCanDelegate")
-    .li-delegate__value.checkbox#remove-from-cart(v-if="inCart" @click='rm(delegate)')
+    .li-delegate__value.checkbox(v-if="amountBonded > 0")
+      i.material-icons check_box
+    .li-delegate__value.checkbox#remove-from-cart(v-else-if="inCart" @click='rm(delegate)')
       i.material-icons check_box
     .li-delegate__value.checkbox#add-to-cart(v-else @click='add(delegate)')
       i.material-icons check_box_outline_blank
@@ -38,7 +40,7 @@ export default {
     },
     styles () {
       let value = ''
-      if (this.inCart) value += 'li-delegate-active '
+      if (this.inCart || this.amountBonded > 0) value += 'li-delegate-active '
       if (this.delegate.isValidator) value += 'li-delegate-validator '
       return value
     },

--- a/app/src/renderer/components/staking/LiDelegate.vue
+++ b/app/src/renderer/components/staking/LiDelegate.vue
@@ -8,12 +8,12 @@
     span {{ num.prettyInt(delegate.voting_power) }}
     .bar(:style='vpStyles')
   .li-delegate__value.bonded_by_you
-    span {{ amountBonded }}
+    span {{ bondedByYou }}
   .li-delegate__value.status
     span {{ delegateType }}
   template(v-if="userCanDelegate")
-    .li-delegate__value.checkbox(v-if="amountBonded > 0")
-      i.material-icons check_box
+    .li-delegate__value.checkbox(v-if="bondedByYou > 0")
+      i.material-icons lock
     .li-delegate__value.checkbox#remove-from-cart(v-else-if="inCart" @click='rm(delegate)')
       i.material-icons check_box
     .li-delegate__value.checkbox#add-to-cart(v-else @click='add(delegate)')
@@ -35,12 +35,12 @@ export default {
   },
   computed: {
     ...mapGetters(['shoppingCart', 'delegates', 'config', 'committedDelegations', 'user']),
-    amountBonded () {
+    bondedByYou () {
       return this.num.prettyInt(this.committedDelegations[this.delegate.id])
     },
     styles () {
       let value = ''
-      if (this.inCart || this.amountBonded > 0) value += 'li-delegate-active '
+      if (this.inCart || this.bondedByYou > 0) value += 'li-delegate-active '
       if (this.delegate.isValidator) value += 'li-delegate-validator '
       return value
     },
@@ -80,6 +80,13 @@ export default {
   methods: {
     add (delegate) { this.$store.commit('addToCart', delegate) },
     rm (delegate) { this.$store.commit('removeFromCart', delegate.id) }
+  },
+  watch: {
+    bondedByYou (newVal, oldVal) {
+      if (newVal > 0) {
+        this.$store.commit('addToCart', this.delegate)
+      }
+    }
   }
 }
 </script>

--- a/app/src/renderer/components/staking/LiDelegate.vue
+++ b/app/src/renderer/components/staking/LiDelegate.vue
@@ -150,6 +150,7 @@ export default {
 
   &.checkbox
     justify-content center
+    cursor pointer
 
   span
     white-space nowrap

--- a/app/src/renderer/components/staking/PageBond.vue
+++ b/app/src/renderer/components/staking/PageBond.vue
@@ -54,7 +54,6 @@ page.page-bond(title="Bond Atoms")
           label.bond-delta
             span(v-if="d.deltaAtoms !== 0") {{ d.deltaAtoms }}
           field.bond-value__input(
-            :id="`${d.id}-atoms`"
             type="number"
             placeholder="Atoms"
             step="1"

--- a/app/src/renderer/components/staking/PageBond.vue
+++ b/app/src/renderer/components/staking/PageBond.vue
@@ -54,10 +54,14 @@ page.page-bond(title="Bond Atoms")
           label.bond-delta
             span(v-if="d.deltaAtoms !== 0") {{ d.deltaAtoms }}
           field.bond-value__input(
+            :id="`${d.id}-atoms`"
             type="number"
             placeholder="Atoms"
             step="1"
-            v-model.number="d.atoms")
+            min="0"
+            :max="$v.fields.delegates.$each[index].atoms.$params.between.max"
+            v-model.number="d.atoms"
+            @change.native="limitMax(d, $event)")
 
       form-msg(name="Atoms" type="required"
         v-if="!$v.fields.delegates.$each[index].atoms.required")
@@ -149,10 +153,6 @@ export default {
     oldUnbondedAtoms () {
       return this.totalAtoms - this.oldBondedAtoms
     },
-    // not used
-    // newBondedAtoms () {
-    //   return this.fields.delegates.reduce((sum, d) => sum + (d.atoms || 0), 0)
-    // },
     newUnbondedAtoms () {
       return this.fields.delegates.reduce((atoms, d) => {
         let delta = d.oldAtoms - d.atoms
@@ -325,6 +325,14 @@ export default {
         value = Math.round(ratio * 100)
       }
       return value + '%'
+    },
+    limitMax (delegate, event) {
+      let max = parseInt(event.target.max)
+      if (delegate.atoms >= max) {
+        console.log(`${delegate.atoms} <= ${max}`)
+        delegate.atoms = max
+        return
+      }
     }
   },
   async mounted () {

--- a/app/src/renderer/components/staking/PageBond.vue
+++ b/app/src/renderer/components/staking/PageBond.vue
@@ -301,7 +301,6 @@ export default {
         d.deltaAtomsPercent =
           this.percent(this.delta(rawAtoms, d.oldAtoms), this.totalAtoms)
       }
-      return d.atoms
     },
     setBondBarOuterWidth () {
       let outerBar = this.$el.querySelector('.bond-bar__outer')

--- a/app/src/renderer/components/staking/PageBond.vue
+++ b/app/src/renderer/components/staking/PageBond.vue
@@ -283,14 +283,17 @@ export default {
           restrictSize: { min: { width: offset } }
         })
         .on('resizemove', (event) => {
-          let target = event.target
-          let ratio = (event.rect.width - offset) / (this.bondBarOuterWidth - offset)
-          let rawAtoms = ratio * this.totalAtoms
-
-          target.style.width = event.rect.width + 'px'
-
-          this.updateDelegateAtoms(target.id.split('-')[1], rawAtoms)
+          this.handleResize (event.target, event.rect.width)
         })
+    },
+    handleResize (element, width) {
+      let offset = this.bondBarScrubWidth
+      let ratio = Math.round((width - offset) / (this.bondBarOuterWidth - offset) * 100) / 100
+      let rawAtoms = ratio * this.totalAtoms
+
+      element.style.width = width + 'px'
+
+      return this.updateDelegateAtoms(element.id.split('-')[1], rawAtoms)
     },
     updateDelegateAtoms (delegateId, rawAtoms) {
       let d = this.fields.delegates.find(d => d.id === delegateId)
@@ -300,6 +303,7 @@ export default {
         d.deltaAtoms = this.delta(rawAtoms, d.oldAtoms, 'int')
         d.deltaAtomsPercent =
           this.percent(this.delta(rawAtoms, d.oldAtoms), this.totalAtoms)
+        return d
       }
     },
     setBondBarOuterWidth () {

--- a/app/src/renderer/components/staking/PageBond.vue
+++ b/app/src/renderer/components/staking/PageBond.vue
@@ -283,7 +283,7 @@ export default {
           restrictSize: { min: { width: offset } }
         })
         .on('resizemove', (event) => {
-          this.handleResize (event.target, event.rect.width)
+          this.handleResize(event.target, event.rect.width)
         })
     },
     handleResize (element, width) {

--- a/app/src/renderer/components/staking/PageBond.vue
+++ b/app/src/renderer/components/staking/PageBond.vue
@@ -205,8 +205,8 @@ export default {
         this.$store.commit('activateDelegation')
         try {
           await this.$store.dispatch('submitDelegation', this.fields)
-          this.$store.commit('notify', { title: 'Atoms Bonded',
-            body: 'You have successfully updated your delegations.' })
+          this.$store.commit('notify', { title: 'Successful Delegation',
+            body: 'You have successfully bonded / unbonded.' })
           this.$router.push('/staking')
         } catch (err) {
           this.$store.commit('notifyError', { title: 'Error While Bonding Atoms',

--- a/app/src/renderer/components/staking/PageDelegates.vue
+++ b/app/src/renderer/components/staking/PageDelegates.vue
@@ -30,7 +30,6 @@ page(title='Validators and Candidates')
 <script>
 import { mapGetters } from 'vuex'
 import { includes, orderBy } from 'lodash'
-import indicateValidators from 'scripts/indicateValidators'
 import Mousetrap from 'mousetrap'
 import LiDelegate from 'staking/LiDelegate'
 import Btn from '@nylira/vue-button'
@@ -103,7 +102,6 @@ export default {
     Mousetrap.bind(['command+f', 'ctrl+f'], () => this.setSearch(true))
     Mousetrap.bind('esc', () => this.setSearch(false))
     await this.updateDelegates(this.user.address)
-    indicateValidators(this.delegates.delegates, this.config.maxValidators)
   }
 }
 </script>

--- a/app/src/renderer/vuex/modules/delegates.js
+++ b/app/src/renderer/vuex/modules/delegates.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import indicateValidators from 'scripts/indicateValidators'
 
 export default ({ dispatch, node }) => {
   const state = {
@@ -24,14 +25,15 @@ export default ({ dispatch, node }) => {
   }
 
   const actions = {
-    async getDelegates ({ state, dispatch }) {
+    async getDelegates ({ state, dispatch, rootState }) {
       state.loading = true
       let delegatePubkeys = (await node.candidates()).data
-      let delegates = await Promise.all(delegatePubkeys.map(pubkey => {
+      await Promise.all(delegatePubkeys.map(pubkey => {
         return dispatch('getDelegate', pubkey)
       }))
+      state.delegates = indicateValidators(state.delegates, rootState.config.maxValidators)
       state.loading = false
-      return delegates
+      return state.delegates
     },
     async getDelegate ({ commit }, pubkey) {
       let delegate = (await axios.get(`http://localhost:${node.relayPort}/query/stake/candidate/${pubkey.data}`)).data.data

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "@nylira/vue-button": "^4.3.2",
     "@nylira/vue-field": "^1.1.17",
     "@nylira/vue-form-msg": "^1.0.3",
-    "@nylira/vue-input": "^3.2.0",
     "@nylira/vue-notifications": "^1.4.4",
     "@vue/test-utils": "^1.0.0-beta.11",
     "axios": "^0.17.0",

--- a/test/unit/specs/components/staking/PageBond.spec.js
+++ b/test/unit/specs/components/staking/PageBond.spec.js
@@ -94,6 +94,11 @@ describe('PageBond', () => {
     expect(delegate.atoms).toBe(88)
   })
 
+  it('only shows percent based on showing atoms', () => {
+    let updatedDelegate = wrapper.vm.handleResize(wrapper.vm.$el.querySelector('#delegate-pubkeyX'), 0.12)
+    expect(updatedDelegate.deltaAtomsPercent).toBe('100%')
+  })
+
   it('calculates delta', () => {
     expect(wrapper.vm.delta(100.23293423, 90.5304934)).toBe(9.70244083)
     expect(wrapper.vm.delta(100, 90, 'int')).toBe(10)

--- a/test/unit/specs/components/staking/__snapshots__/PageBond.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageBond.spec.js.snap
@@ -242,6 +242,9 @@ exports[`PageBond has the expected html structure 1`] = `
                       </label>
                       <input
                         class="bond-value__input ni-field"
+                        id="pubkeyX-atoms"
+                        max="101"
+                        min="0"
                         placeholder="Atoms"
                         step="1"
                         type="number"
@@ -312,6 +315,9 @@ exports[`PageBond has the expected html structure 1`] = `
                       </label>
                       <input
                         class="bond-value__input ni-field"
+                        id="pubkeyY-atoms"
+                        max="101"
+                        min="0"
                         placeholder="Atoms"
                         step="1"
                         type="number"

--- a/test/unit/specs/components/staking/__snapshots__/PageBond.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageBond.spec.js.snap
@@ -242,7 +242,6 @@ exports[`PageBond has the expected html structure 1`] = `
                       </label>
                       <input
                         class="bond-value__input ni-field"
-                        id="pubkeyX-atoms"
                         max="101"
                         min="0"
                         placeholder="Atoms"
@@ -315,7 +314,6 @@ exports[`PageBond has the expected html structure 1`] = `
                       </label>
                       <input
                         class="bond-value__input ni-field"
-                        id="pubkeyY-atoms"
                         max="101"
                         min="0"
                         placeholder="Atoms"

--- a/test/unit/specs/components/staking/__snapshots__/PageDelegates.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageDelegates.spec.js.snap
@@ -81,7 +81,7 @@ exports[`PageDelegates has the expected html structure 1`] = `
 </div>
 </div>
 </div>
-   <div class=\\"li-delegate\\">
+   <div class=\\"li-delegate li-delegate-validator \\">
       <div class=\\"li-delegate__values\\">
          <div class=\\"li-delegate__value name\\">
             <a href=\\"#/staking/delegates/pubkeyY\\" class=\\"\\">candidateY</a>
@@ -97,14 +97,14 @@ exports[`PageDelegates has the expected html structure 1`] = `
       <span>0</span>
    </div>
    <div class=\\"li-delegate__value status\\">
-      <span>Candidate</span>
+      <span>Validator</span>
    </div>
    <div id=\\"add-to-cart\\" class=\\"li-delegate__value checkbox\\">
       <i class=\\"material-icons\\">check_box_outline_blank</i>
    </div>
 </div>
 </div>
-   <div class=\\"li-delegate\\">
+   <div class=\\"li-delegate li-delegate-validator \\">
       <div class=\\"li-delegate__values\\">
          <div class=\\"li-delegate__value name\\">
             <a href=\\"#/staking/delegates/pubkeyX\\" class=\\"\\">candidateX</a>
@@ -120,7 +120,7 @@ exports[`PageDelegates has the expected html structure 1`] = `
       <span>0</span>
    </div>
    <div class=\\"li-delegate__value status\\">
-      <span>Candidate</span>
+      <span>Validator</span>
    </div>
    <div id=\\"add-to-cart\\" class=\\"li-delegate__value checkbox\\">
       <i class=\\"material-icons\\">check_box_outline_blank</i>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,16 +11,12 @@
   resolved "https://registry.yarnpkg.com/@nylira/vue-button/-/vue-button-4.3.2.tgz#f27b90a931a1a3b5e27736dba11dfcaa305d6ddb"
 
 "@nylira/vue-field@^1.1.17":
-  version "1.1.17"
-  resolved "https://registry.yarnpkg.com/@nylira/vue-field/-/vue-field-1.1.17.tgz#a873c2d5e01b7ec664df0de71611b0fd9e066b97"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@nylira/vue-field/-/vue-field-1.2.3.tgz#47b5cde79bbb9d2993b4f5734304e0424734dab1"
 
 "@nylira/vue-form-msg@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@nylira/vue-form-msg/-/vue-form-msg-1.0.3.tgz#257e3fcb1da345690f4fba959372b70e8abc9c20"
-
-"@nylira/vue-input@^3.2.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@nylira/vue-input/-/vue-input-3.4.0.tgz#741346ce0613b831b756fccb253731015fa5c246"
 
 "@nylira/vue-notifications@^1.4.4":
   version "1.4.4"


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull your feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **develop branch** (left side). Also make sure to start *your branch* off *our develop*.
- [x] If this PR produces a visible change, please provide screenshots showing these changes.
- [x] Confirm that your pull request will pass our linting and unit tests.
- [x] Make sure your code is properly tested, so that the code coverage is not decreasing.

### Changes checklist
- [x] on PageDelegates, delegates that the user have bonded to before are automatically checked and locked for use on PageBond. Because it doesn't make sense to allow the user to only bond a portion of their atoms, and it'll be confusing when it shows them that they only have a few unbonded atoms left.
- [x] bonding bar width is limited to remaining user atoms when increasing bonded atoms via the numerical input field
- [x] numerical input field for atoms per delegate has a min and max limit so that clicking the up and down arrows for the field don't pass 0 or max
- [x] resolve bonding bar width bug where it scales out of control
- [x] resolve lack of unbonding message


### Screenshots
The screenshot below shows what happens on PageDelegates on initial load, if the user has already delegated atoms in the past. Those validators are already checked and cannot be unchecked. If they want to 'uncheck' those validators they have to unbond from them first.

<img width="783" alt="screen shot 2018-02-14 at 4 22 55 pm" src="https://user-images.githubusercontent.com/172531/36194083-585bbbce-11a3-11e8-89cb-62812cfb40c1.png">

### Issue
Closes #453 
Closes #455 