### PR TITLE
hide unbond bar when there are no previous bonded atoms

### DIFF
--- a/app/src/renderer/components/staking/PageBond.vue
+++ b/app/src/renderer/components/staking/PageBond.vue
@@ -36,7 +36,7 @@ page.page-bond(title="Bond Atoms")
       :class="bondGroupClass(delta(d.atoms, d.oldAtoms))")
       .bond-group__fields
         .bond-bar
-          label.bond-bar__label {{ d.delegate.description.moniker }}
+          label.bond-bar__label {{ d.delegate.moniker }}
           .bond-bar__input
             .bond-bar-old__outer
               .bond-bar-old__inner(:style="styleBondBarInner(d.oldAtoms)")
@@ -70,6 +70,7 @@ page.page-bond(title="Bond Atoms")
         v-if="!$v.fields.delegates.$each[index].atoms.between")
 
     .bond-group.bond-group--unbonding(
+      v-if="oldBondedAtoms > 0"
       :class="bondGroupClass(newUnbondingAtomsDelta)")
       .bond-group__fields
         .bond-bar

--- a/test/unit/specs/components/staking/PageBond.spec.js
+++ b/test/unit/specs/components/staking/PageBond.spec.js
@@ -25,11 +25,9 @@ describe('PageBond', () => {
       },
       voting_power: 10000,
       shares: 5000,
-      description: {
-        description: 'descriptionX',
-        country: 'USA',
-        moniker: 'someValidator'
-      }
+      description: 'descriptionX',
+      country: 'USA',
+      moniker: 'someValidator'
     })
     store.commit('addToCart', {
       id: 'pubkeyY',
@@ -39,11 +37,9 @@ describe('PageBond', () => {
       },
       voting_power: 30000,
       shares: 10000,
-      description: {
-        description: 'descriptionY',
-        country: 'Canada',
-        moniker: 'someOtherValidator'
-      }
+      description: 'descriptionY',
+      country: 'Canada',
+      moniker: 'someOtherValidator'
     })
 
     wrapper.update()
@@ -194,6 +190,10 @@ describe('PageBond', () => {
   })
 
   it('shows an appropriate amount of unbonding atoms', () => {
+    // give some stake so unbinding bar shows
+    store.commit('setCommittedDelegation', { candidateId: 'pubkeyX', value: 5 })
+    wrapper.update()
+
     wrapper.setData({
       fields: {
         bondConfirm: false,
@@ -291,5 +291,10 @@ describe('PageBond', () => {
     })
     wrapper.findAll('#btn-bond').trigger('click')
     expect(store.dispatch.mock.calls[0][0]).toBe('submitDelegation')
+  })
+
+  it('does not show the unbonding bar if user has no atoms', () => {
+    expect(wrapper.vm.oldBondedAtoms).toBe(0)
+    expect(wrapper.vm.$el.querySelector('.bond-group.bond-group--unbonding')).toBeNull()
   })
 })

--- a/test/unit/specs/components/staking/__snapshots__/PageBond.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageBond.spec.js.snap
@@ -326,58 +326,7 @@ exports[`PageBond has the expected html structure 1`] = `
                   <!---->
                   <!---->
                 </div>
-                <div
-                  class="bond-group bond-group--unbonding bond-group--neutral"
-                >
-                  <div
-                    class="bond-group__fields"
-                  >
-                    <div
-                      class="bond-bar"
-                    >
-                      <label
-                        class="bond-bar__label"
-                      >
-                        Unbonding…
-                      </label>
-                      <div
-                        class="bond-bar__input"
-                      >
-                        <!---->
-                      </div>
-                    </div>
-                    <div
-                      class="bond-percent"
-                    >
-                      <label
-                        class="bond-delta"
-                      >
-                        <!---->
-                      </label>
-                      <input
-                        class="bond-percent__input ni-field"
-                        disabled="disabled"
-                        placeholder="0%"
-                      />
-                    </div>
-                    <div
-                      class="bond-value"
-                    >
-                      <label
-                        class="bond-delta"
-                      >
-                        <!---->
-                      </label>
-                      <input
-                        class="bond-value__input ni-field"
-                        disabled="disabled"
-                        id="new-unbonding-atoms"
-                        placeholder="Atoms"
-                        type="number"
-                      />
-                    </div>
-                  </div>
-                </div>
+                <!---->
                 <div
                   class="ni-form-group"
                 >


### PR DESCRIPTION
> Thank you a lot for contributing to Cosmos Voyager!
<!-- Please confirm that your pull request will pass our linting and unit tests. -->
<!-- Please make sure your code is properly tested, so that the code coverage is not decreasing. -->

### Issue
<!-- Please provide the `#123` of the issue you created in advance, that describes the bug/proposed change. This will automatically close the issue. -->
closes: 529

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/5869273/37766968-e2a03350-2dc8-11e8-9952-677eca0aa8ff.png)

Now:
![image](https://user-images.githubusercontent.com/5869273/37766939-d2e833ae-2dc8-11e8-9694-e8ce5f6cde1c.png)



❤️ Thank you!
