### PR TITLE
Lint: Fix broken glob patterns.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "testnet": "node tasks/testnet.js",
     "lint": "yarn lint:eslint && yarn lint:format",
     "lint:eslint":
-      "eslint -f ./node_modules/eslint-friendly-formatter {,**/}*.{js,vue}",
-    "lint:format": "prettier --list-different {,**/}*.{css,js,json,vue}",
-    "lint:fix": "prettier --write {,**/}*.{css,js,json,vue}",
+      "eslint -f ./node_modules/eslint-friendly-formatter '{,**/}*.{js,vue}'",
+    "lint:format": "prettier --list-different '{,**/}*.{css,js,json,vue}'",
+    "lint:fix": "prettier --write '{,**/}*.{css,js,json,vue}'",
     "pack": "yarn run pack:main && yarn run pack:renderer",
     "pack:main":
       "cross-env NODE_ENV=production webpack --colors --config webpack.main.config.js",


### PR DESCRIPTION
The patterns must be quoted using single quotes because the shells on different platforms (e.g., macOS & Linux) expand globs differently.

> Thank you a lot for contributing to Cosmos Voyager!

<!-- Please confirm that your pull request will pass our linting and unit tests. -->

<!-- Please make sure your code is properly tested, so that the code coverage is not decreasing. -->

### Issue

<!-- Please provide the `#123` of the issue you created in advance, that describes the bug/proposed change. This will automatically close the issue. -->

closes: ISSUE

### Screenshots

<!-- If this PR produces a visible change, please provide screenshots showing these changes. -->

❤️ Thank you!
