### PR TITLE
peng/disable e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Turn off E2E test.
+
+## [0.5.0]
+
 ### Added
 
 * The following file types are now formatted with [Prettier](https://prettier.io/): css, js, json, vue.
@@ -100,4 +106,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.3.0] - 2018-01-15
 
 ### Added
+
 * Added a changelog @jolesbi.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "cross-env NODE_ENV=production webpack --colors --config webpack.main.config.js",
     "pack:renderer":
       "cross-env NODE_ENV=production webpack --colors --config webpack.renderer.config.js",
-    "test": "yarn run lint && yarn test:unit && yarn test:e2e",
+    "test": "yarn run lint && yarn test:unit",
     "test:unit":
       "cross-env LOGGING=false MOCK=false ANALYTICS=false NODE_ENV=testing jest --maxWorkers=2",
     "test:e2e":


### PR DESCRIPTION
Based on the last three meetings, let's consider disabling all E2E tests for now. Reasoning: our progress has been blocking on cryptic E2E errors while unit testing and user testing has been successful. When @faboweb returns, we can discuss refactoring/reducing the tests.

- [x] remove e2e test from overall suite
- [x] allows #591 to pass status checks