### PR TITLE
fix onboarding persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Windows build now compresses `zip` file. @NodeGuy
 * Fixed block explorer @faboweb
+* Fixed onboarding window appearing everytime @faboweb
 
 ## [0.5.0]
 

--- a/app/src/renderer/vuex/modules/onboarding.js
+++ b/app/src/renderer/vuex/modules/onboarding.js
@@ -6,9 +6,12 @@ export default ({ commit }) => {
   const mutations = {
     loadOnboarding(state) {
       // localstorage saves bools and ints as strings, so we have to convert
-      state.active =
-        JSON.parse(localStorage.getItem("appOnboardingActive")) || true
-      state.state = JSON.parse(localStorage.getItem("appOnboardingState")) || 0
+      state.active = JSON.parse(
+        localStorage.getItem("appOnboardingActive") || "true"
+      )
+      state.state = JSON.parse(
+        localStorage.getItem("appOnboardingState") || "0"
+      )
     },
     setOnboardingState(state, value) {
       state.state = value

--- a/test/e2e/common.js
+++ b/test/e2e/common.js
@@ -82,9 +82,6 @@ module.exports = {
     await app.client.$("#sign-in-password").setValue("1234567890")
     await app.client.$(".ni-session-footer button").click()
 
-    // the onboarding dialog opens for first time logins
-    await module.exports.closeOnboarding(app)
-
     await app.client.waitForExist("#app-content", 5000)
 
     // checking if user is logged in
@@ -111,10 +108,6 @@ module.exports = {
       .$(".material-icons=exit_to_app")
       .$("..")
       .click()
-  },
-  async closeOnboarding(app) {
-    await app.client.waitForVisible("#onboarding")
-    await app.client.$("#onboarding .ni-session-footer button").click()
   }
 }
 

--- a/test/e2e/launch.js
+++ b/test/e2e/launch.js
@@ -116,9 +116,15 @@ function launch(t) {
         "cream another bring skill effort narrow crumble ball trouble verify mother confirm recall rain armor abandon"
       )
       console.log("setup test accounts")
-      await startApp(app, ".ni-session-title=Sign In")
 
+      await startApp(app, ".ni-session-title=Sign In")
       t.ok(app.isRunning(), "app is running")
+
+      // disable the onboarding wizard
+      await app.client.localStorage("POST", {
+        key: "appOnboardingActive",
+        value: "false"
+      })
 
       resolve({ app, cliHome })
     })

--- a/test/e2e/signin.js
+++ b/test/e2e/signin.js
@@ -1,6 +1,6 @@
 let test = require("tape-promise/tape")
 let { getApp, restart, refresh } = require("./launch.js")
-let { openMenu, login, closeOnboarding } = require("./common.js")
+let { openMenu, login } = require("./common.js")
 
 /*
 * NOTE: For some strange reason element.click() does not always work. In some cases I needed to use client.leftClick(selector). But this will be deprecated and pollutes the console with a deprecation warning.
@@ -145,8 +145,6 @@ test("sign in", async function(t) {
 
     t.test("logs in", async function(t) {
       await clickContinue()
-
-      await closeOnboarding(app)
 
       // checking if user is logged in
       await app.client.waitForExist("#app-content", 10000)
@@ -298,8 +296,6 @@ test("sign in", async function(t) {
 
     t.test("logs in", async function(t) {
       await clickContinue()
-
-      await closeOnboarding(app)
 
       // checking if user is logged in
       await app.client.waitForExist("#app-content", 5000)

--- a/test/unit/specs/store/onboarding.spec.js
+++ b/test/unit/specs/store/onboarding.spec.js
@@ -25,4 +25,18 @@ describe("Module: Onboarding", () => {
     store.commit("setOnboardingState", 0)
     expect(state.state).toBe(0)
   })
+
+  it("loads the onboarding active state from localStorage", () => {
+    store.commit("setOnboardingActive", false)
+    state.active = true
+    store.commit("loadOnboarding")
+    expect(state.active).toBe(false)
+  })
+
+  it("loads the onboarding state from localStorage", () => {
+    store.commit("setOnboardingState", 3)
+    state.state = 1
+    store.commit("loadOnboarding")
+    expect(state.state).toBe(3)
+  })
 })


### PR DESCRIPTION
> Thank you a lot for contributing to Cosmos Voyager!

<!-- Please confirm that your pull request will pass our linting and unit tests. -->

<!-- Please make sure your code is properly tested, so that the code coverage is not decreasing. -->

### Issue

<!-- Please provide the `#123` of the issue you created in advance, that describes the bug/proposed change. This will automatically close the issue. -->

closes: #716 

Also deactivates the onboarding wizard in the e2e tests for simplicity by setting the localStorage value to false.

❤️ Thank you!
