### PR TITLE
Send fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 * Removed some defaults when building a release to reduce confusion.
+* Fixed a bug where errors that occurred while sending a transaction would prevent further sends from succeeding.
 
 ## [0.6.0]
 

--- a/test/unit/specs/store/send.spec.js
+++ b/test/unit/specs/store/send.spec.js
@@ -58,5 +58,28 @@ describe("Module: Send", () => {
       await store.dispatch("sendTx", args)
       expect(node.ibcSend.mock.calls).toMatchSnapshot()
     })
+
+    it("should send a transaction after failing", async () => {
+      let send = node.send.bind(node)
+
+      node.send = () => Promise.reject(true)
+      const args = { to: "address", amount: [{ denom: "mycoin", amount: 123 }] }
+      let error1
+      try {
+        await store.dispatch("sendTx", args)
+      } catch (err) {
+        error1 = err
+      }
+      expect(error1).toBeDefined()
+
+      node.send = send
+      let error2
+      try {
+        await store.dispatch("sendTx", args)
+      } catch (err) {
+        error2 = err
+      }
+      expect(error2).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
> Thank you a lot for contributing to Cosmos Voyager!

<!-- Please confirm that your pull request will pass our linting and unit tests. -->

<!-- Please make sure your code is properly tested, so that the code coverage is not decreasing. -->

Fixed the issue where the send lock wouldn't get unset when an error occurred, causing future sends to fail. Also added a test case for this to prevent regressions.

### Issue

<!-- Please provide the `#123` of the issue you created in advance, that describes the bug/proposed change. This will automatically close the issue. -->

closes #694 

### Screenshots

<!-- If this PR produces a visible change, please provide screenshots showing these changes. -->

❤️ Thank you!
