### PR TITLE
fix lcd reconnection after mocked connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Removed some defaults when building a release to reduce confusion.
 
+### Fixed
+
+* Reconnection when coming back from mocked connection works again @faboweb
+
 ## [0.6.0]
 
 ### Added

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -253,11 +253,17 @@ async function startLCD(home, nodeIP) {
 }
 
 function stopLCD() {
-  log("Stopping the LCD server")
-  // prevent the exit to signal bad termination warnings
-  lcdProcess.removeAllListeners("exit")
-  lcdProcess.kill("SIGKILL")
-  lcdProcess = null
+  return new Promise(resolve => {
+    if (!lcdProcess) {
+      resolve()
+    }
+    log("Stopping the LCD server")
+    // prevent the exit to signal bad termination warnings
+    lcdProcess.removeAllListeners("exit")
+    lcdProcess.on("exit", resolve)
+    lcdProcess.kill("SIGKILL")
+    lcdProcess = null
+  })
 }
 
 async function getGaiacliVersion() {
@@ -517,7 +523,7 @@ async function reconnect(seeds) {
     if (!nodeAlive) await sleep(2000)
   }
 
-  stopLCD()
+  await stopLCD()
 
   await connect(nodeIP)
 }

--- a/test/unit/specs/main.spec.js
+++ b/test/unit/specs/main.spec.js
@@ -385,6 +385,10 @@ describe("Startup Process", () => {
     })
 
     it("should reconnect on IPC call", async () => {
+      // the lcd process gets terminated and waits for the exit to continue so we need to trigger this event in our mocked process as well
+      main.processes.lcdProcess.on = (type, cb) => {
+        if (type === "exit") cb()
+      }
       await registeredIPCListeners["reconnect"]()
 
       expect(
@@ -400,6 +404,11 @@ describe("Startup Process", () => {
     })
 
     it("should not start reconnecting again if already trying to reconnect", async () => {
+      // the lcd process gets terminated and waits for the exit to continue so we need to trigger this event in our mocked process as well
+      main.processes.lcdProcess.on = (type, cb) => {
+        if (type === "exit") cb()
+      }
+
       let axios = require("axios")
       let spy = jest.spyOn(axios, "get")
       spy.mockImplementationOnce(async () => {
@@ -412,6 +421,11 @@ describe("Startup Process", () => {
     })
 
     it("should search through nodes until it finds one", async () => {
+      // the lcd process gets terminated and waits for the exit to continue so we need to trigger this event in our mocked process as well
+      main.processes.lcdProcess.on = (type, cb) => {
+        if (type === "exit") cb()
+      }
+
       let axios = require("axios")
       axios.get = jest
         .fn()


### PR DESCRIPTION
> Thank you a lot for contributing to Cosmos Voyager!

<!-- Please confirm that your pull request will pass our linting and unit tests. -->

<!-- Please make sure your code is properly tested, so that the code coverage is not decreasing. -->

### Issue

<!-- Please provide the `#123` of the issue you created in advance, that describes the bug/proposed change. This will automatically close the issue. -->

part of #720 

The problem was, that the main process wanted to stop the lcd process after is was already stopped. The error was not properly surfaced.

❤️ Thank you!
