### PR TITLE
Fabo/774 upload e2e screenshot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/test_info
-            [ -f test/e2e/snapshot.png ] && cp test/e2e/snapshot.png /tmp/test_info
+            [ -f test/e2e/snapshot.png ] && cp test/e2e/snapshot.png /tmp/test_info || echo "No screenshot found"
           when: on_fail
       - store_artifacts:
           path: /tmp/test_info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/test_info
-            cp test/e2e/snapshot.png /tmp/test_info
+            [ -f test/e2e/snapshot.png ] && cp test/e2e/snapshot.png /tmp/test_info
           when: on_fail
       - store_artifacts:
           path: /tmp/test_info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,4 +46,13 @@ jobs:
           name: Test
           command: yarn run test
           no_output_timeout: 120
-      - run: bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+      - run: 
+          command: bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+          when: on_success
+      - run:
+          command: |
+            mkdir -p /tmp/test_info
+            cp test/e2e/snapshot.png /tmp/test_info
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/test_info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Persisting e2e failure screenshots as artifact on circleci @faboweb
+
 ## [0.6.2] - 2018-05-23
 
 ### Added

--- a/test/e2e/signin.js
+++ b/test/e2e/signin.js
@@ -59,7 +59,6 @@ test("sign in", async function(t) {
           .isExisting(".ni-form-msg--error")),
         "hides error"
       )
-      throw Error("EXPECTED ERROR")
       t.end()
     })
 

--- a/test/e2e/signin.js
+++ b/test/e2e/signin.js
@@ -59,6 +59,7 @@ test("sign in", async function(t) {
           .isExisting(".ni-form-msg--error")),
         "hides error"
       )
+      throw Error("EXPECTED ERROR")
       t.end()
     })
 


### PR DESCRIPTION
Implements part of #774

Description:

Stores the screenshot of a failed e2e test as an artifact.
![image](https://user-images.githubusercontent.com/5869273/40833788-2e542902-658f-11e8-99db-2901a561994c.png)

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
