### PR TITLE
Billy/764 theme switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fixed minor typo in README.md @nylira
 * Tx bug where state wasn't updated @okwme
 * Persisting e2e failure screenshots as artifact on circleci @faboweb
+* Theme switching bug @okwme
 
 ## [0.6.2] - 2018-05-23
 

--- a/app/src/renderer/components/common/PagePreferences.vue
+++ b/app/src/renderer/components/common/PagePreferences.vue
@@ -65,7 +65,7 @@ export default {
     ...mapGetters(["user", "themes", "onboarding", "mockedConnector"])
   },
   data: () => ({
-    themeSelectActive: "light",
+    themeSelectActive: null,
     themeSelectOptions: [
       {
         value: "light",
@@ -76,7 +76,7 @@ export default {
         key: "Dark"
       }
     ],
-    networkSelectActive: "live",
+    networkSelectActive: null,
     networkSelectOptions: [
       {
         value: "live",
@@ -98,10 +98,10 @@ export default {
       this.$store.commit("notifySignOut")
     },
     setAppTheme() {
-      if (this.themes.active === "light") {
-        this.$store.commit("setTheme", "dark")
-      } else {
+      if (this.themes.active === "dark") {
         this.$store.commit("setTheme", "light")
+      } else {
+        this.$store.commit("setTheme", "dark")
       }
     },
     setErrorCollection() {

--- a/app/src/renderer/components/common/PagePreferences.vue
+++ b/app/src/renderer/components/common/PagePreferences.vue
@@ -13,10 +13,10 @@ page(title="Preferences")
     list-item(type="field" title="Select theme")
       field#select-theme(
         type="select"
-        v-model="themes.active"
+        v-model="themeSelectActive"
         :options="themeSelectOptions"
         placeholder="Select theme..."
-        @change="setAppTheme")
+        @change.native="setAppTheme")
     list-item(type="field" title="View tutorial for Voyager")
       btn#toggle-onboarding(
         @click.native="setOnboarding"
@@ -65,6 +65,7 @@ export default {
     ...mapGetters(["user", "themes", "onboarding", "mockedConnector"])
   },
   data: () => ({
+    themeSelectActive: "light",
     themeSelectOptions: [
       {
         value: "light",
@@ -89,6 +90,7 @@ export default {
   }),
   mounted() {
     this.networkSelectActive = this.mockedConnector ? "mock" : "live"
+    this.themeSelectActive = this.themes.active
   },
   methods: {
     signOut() {
@@ -96,10 +98,10 @@ export default {
       this.$store.commit("notifySignOut")
     },
     setAppTheme() {
-      if (this.themes.active === "dark") {
-        this.$store.commit("setTheme", "light")
-      } else {
+      if (this.themes.active === "light") {
         this.$store.commit("setTheme", "dark")
+      } else {
+        this.$store.commit("setTheme", "light")
       }
     },
     setErrorCollection() {


### PR DESCRIPTION
Closes #764 

Description: I actually didn't see any loading screen flashes (except for the app's loading screen which is always white). I did find that the theme switch wasn't getting saved to application state because the store was getting committed via `v-model` and a getter. switched to same technique as network switcher instead.
