### PR TITLE
Fabo/use account number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Improved the visibility and readability of the current network connection. @nylira
 * Updated electron to v2.0.2 @okwme
 * The release builds now have more sensible names. @NodeGuy
+* Transactions use the account number to prevent attacks @faboweb
 
 ### Added
 

--- a/app/src/renderer/vuex/modules/send.js
+++ b/app/src/renderer/vuex/modules/send.js
@@ -15,6 +15,7 @@ export default ({ commit, node }) => {
     args.sequence = state.nonce
     args.name = rootState.user.account
     args.password = rootState.user.password
+    args.account_number = rootState.wallet.accountNumber // TODO move into LCD?
 
     let chainId = rootState.node.lastHeader.chain_id
     // TODO enable again when IBC is enabled

--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -25,6 +25,9 @@ export default ({ commit, node }) => {
     setWalletAddress(state, address) {
       state.address = address
     },
+    setAccountNumber(state, accountNumber) {
+      state.accountNumber = accountNumber
+    },
     setWalletHistory(state, history) {
       state.history = history
     },
@@ -71,6 +74,7 @@ export default ({ commit, node }) => {
         return
       }
       commit("setNonce", res.sequence)
+      commit("setAccountNumber", res.account_number)
       commit("setWalletBalances", res.coins)
       for (let coin of res.coins) {
         if (coin.denom === rootState.config.bondingDenom) {

--- a/test/unit/specs/store/__snapshots__/send.spec.js.snap
+++ b/test/unit/specs/store/__snapshots__/send.spec.js.snap
@@ -5,6 +5,7 @@ Array [
   Array [
     "zone/address",
     Object {
+      "account_number": 123,
       "amount": Array [
         Object {
           "amount": 123,
@@ -25,6 +26,7 @@ Array [
   Array [
     "address",
     Object {
+      "account_number": 123,
       "amount": Array [
         Object {
           "amount": 123,

--- a/test/unit/specs/store/send.spec.js
+++ b/test/unit/specs/store/send.spec.js
@@ -35,6 +35,7 @@ describe("Module: Send", () => {
       node.send = jest.fn(node.send)
       node.ibcSend = jest.fn(node.ibcSend)
       await store.dispatch("signIn", { account, password })
+      await store.commit("setAccountNumber", 123)
     })
 
     it("should send from wallet", async () => {


### PR DESCRIPTION
Description:

Currently transactions do not get accepted by the latest Gaia because they are lacking the account_number which is used to prevent attacks, where a user inherits a formerly removed address.

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
