### PR TITLE
Billy/874 theme bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fixed bug in yarn build:gaia @zramsay
 * Increased version of localtestnet used for testing to match gaia @faboweb
 * Fixed padding issue in main container @faboweb
+* Fixed theme bg bug @okwme
 
 ### Added
 

--- a/app/src/renderer/components/staking/LiDelegate.vue
+++ b/app/src/renderer/components/staking/LiDelegate.vue
@@ -108,6 +108,8 @@ export default {
 @require '~variables'
 
 .li-delegate
+  border-left 1px solid var(--bc)
+  border-right 1px solid var(--bc)
   &:nth-of-type(2n-1)
     background var(--app-bg-light)
   &.li-delegate-active
@@ -161,7 +163,7 @@ export default {
       height 1.5rem
       position relative
       left -0.25rem
-      background var(--accent)
+      background var(--accent-alpha)
 
   &.checkbox
     justify-content center

--- a/app/src/renderer/components/staking/PanelSort.vue
+++ b/app/src/renderer/components/staking/PanelSort.vue
@@ -55,8 +55,8 @@ export default {
   min-width 0
 
   .label
-    font-size var(--sm)
-    color var(--dim)
+    font-weight 500
+    color var(--link)
     white-space nowrap
     text-overflow ellipsis
     overflow hidden
@@ -73,15 +73,11 @@ export default {
   &.desc:after
     content '\f0d7'
 
-  &:not(.active):hover
-    .label
-      color var(--txt)
-
   &.active
     .label
-      color var(--txt)
+      color var(--mc)
     &:after
-      color var(--txt)
+      color var(--mc)
 
   &.name
     flex 2

--- a/app/src/renderer/main.js
+++ b/app/src/renderer/main.js
@@ -1,6 +1,6 @@
 import Vue from "vue"
 import Electron from "vue-electron"
-import Resource from "vue-resource"
+
 import Router from "vue-router"
 import Tooltip from "vue-directive-tooltip"
 import Vuelidate from "vuelidate"
@@ -35,7 +35,7 @@ Vue.config.errorHandler = (error, vm, info) => {
 }
 
 Vue.use(Electron)
-Vue.use(Resource)
+
 Vue.use(Router)
 Vue.use(Tooltip, { delay: 1 })
 Vue.use(Vuelidate)

--- a/app/src/renderer/styles/variables.styl
+++ b/app/src/renderer/styles/variables.styl
@@ -9,16 +9,20 @@
   --bc hsl(233, 22%, 23%)
   --bc-dim hsl(233, 33%, 16%)
   --bc-light hsl(233, 37%, 22%)
+  --box-shadow hsla(0,0,0,0.2)
   --hover-bg hsla(233, 88%, 90%, 0.2)
   --input-bc hsl(233, 22%, 33%)
   --input-bc-hover hsl(233, 22%, 40%)
+
   // change for rebranding
   --mc hsl(325, 96%, 59%)
   --accent hsl(279, 92%, 58%)
+  --accent-alpha hsla(279, 92%, 58%, 0.5)
   --primary hsl(233, 88%, 57%)
   --primary-bc hsl(233, 88%, 43%)
   --link hsl(233, 88%, 82%)
   --hover hsl(233, 88%, 67%)
+
   // don't change
   --input-bg transparent
   --success hsl(120,58%,55%)
@@ -57,7 +61,7 @@ mono()
   font-weight normal
 
 shadow()
-  box-shadow hsla(0,0,0,0.25) 0 0.25rem 0.5rem
+  box-shadow var(--box-shadow) 0 0.25rem 0.25rem
 
 xxl = x * 1.75
 xl = x * 1.5

--- a/app/src/renderer/vuex/json/theme-dark.json
+++ b/app/src/renderer/vuex/json/theme-dark.json
@@ -2,6 +2,7 @@
   "app-fg": "hsl(233, 33%, 16%)",
   "app-bg": "hsl(233, 36%, 13%)",
   "app-bg-alpha": "hsla(233, 36%, 13%, 95%)",
+  "app-bg-light": "hsla(233, 36%, 13%, 95%)",
   "bright": "#fff",
   "txt": "hsl(233, 13%, 85%)",
   "dim": "hsl(233, 13%, 60%)",

--- a/app/src/renderer/vuex/json/theme-dark.json
+++ b/app/src/renderer/vuex/json/theme-dark.json
@@ -1,14 +1,16 @@
 {
-  "app-fg": "hsl(233, 33%, 16%)",
-  "app-bg": "hsl(233, 36%, 13%)",
-  "app-bg-alpha": "hsla(233, 36%, 13%, 95%)",
-  "app-bg-light": "hsla(233, 36%, 13%, 95%)",
-  "bright": "#fff",
-  "txt": "hsl(233, 13%, 85%)",
-  "dim": "hsl(233, 13%, 60%)",
+  "app-fg": "hsl(233, 43%, 10%)",
+  "app-bg": "hsl(233, 37%, 18%)",
+  "app-bg-light": "hsl(233, 40%, 14%)",
+  "app-bg-alpha": "hsla(237, 18%, 20%, 95%)",
+  "txt": "hsl(0, 0%, 100%)",
+  "dim": "hsl(240, 5%, 75%)",
   "bc": "hsl(233, 22%, 23%)",
   "bc-dim": "hsl(233, 33%, 16%)",
-  "hover-bg": "hsl(233, 43%, 10%)",
+  "bc-light": "#dfdfdf",
+  "box-shadow": "hsla(0,0,0,0.2)",
+  "hover-bg": "hsla(233, 88%, 90%, 0.2)",
   "input-bc": "hsl(233, 22%, 33%)",
-  "input-bc-hover": "hsl(233, 22%, 40%)"
+  "input-bc-hover": "hsl(233, 22%, 40%)",
+  "link": "hsl(233, 88%, 82%)"
 }

--- a/app/src/renderer/vuex/json/theme-light.json
+++ b/app/src/renderer/vuex/json/theme-light.json
@@ -2,6 +2,7 @@
   "app-fg": "#f3f3f3",
   "app-bg": "#fff",
   "app-bg-alpha": "hsla(233, 0%, 0%, 5%)",
+  "app-bg-light": "hsla(233, 0%, 0%, 5%)",
   "bright": "#000",
   "txt": "#333",
   "dim": "#666",

--- a/app/src/renderer/vuex/json/theme-light.json
+++ b/app/src/renderer/vuex/json/theme-light.json
@@ -1,14 +1,16 @@
 {
-  "app-fg": "#f3f3f3",
-  "app-bg": "#fff",
+  "app-fg": "hsl(0,0%,92%)",
+  "app-bg": "#f5f5f5",
+  "app-bg-light": "#fff",
   "app-bg-alpha": "hsla(233, 0%, 0%, 5%)",
-  "app-bg-light": "hsla(233, 0%, 0%, 5%)",
-  "bright": "#000",
-  "txt": "#333",
-  "dim": "#666",
+  "txt": "#000",
+  "dim": "#3b3b3b",
   "bc": "#ddd",
-  "bc-dim": "#eee",
-  "hover-bg": "#f3f3f3",
+  "bc-dim": "#cdcbcb",
+  "bc-light": "#dfdfdf",
+  "box-shadow": "hsla(0,0,80%,0.2)",
+  "hover-bg": "hsla(233, 88%, 90%, 0.2)",
   "input-bc": "hsl(233, 22%, 67%)",
-  "input-bc-hover": "hsl(233, 22%, 40%)"
+  "input-bc-hover": "hsl(233, 22%, 40%)",
+  "link": "hsl(233, 88%, 57%)"
 }

--- a/test/unit/specs/store/__snapshots__/themes.spec.js.snap
+++ b/test/unit/specs/store/__snapshots__/themes.spec.js.snap
@@ -2,34 +2,38 @@
 
 exports[`Module: Themes has a dark theme 1`] = `
 Object {
-  "app-bg": "hsl(233, 36%, 13%)",
-  "app-bg-alpha": "hsla(233, 36%, 13%, 95%)",
-  "app-bg-light": "hsla(233, 36%, 13%, 95%)",
-  "app-fg": "hsl(233, 33%, 16%)",
+  "app-bg": "hsl(233, 37%, 18%)",
+  "app-bg-alpha": "hsla(237, 18%, 20%, 95%)",
+  "app-bg-light": "hsl(233, 40%, 14%)",
+  "app-fg": "hsl(233, 43%, 10%)",
   "bc": "hsl(233, 22%, 23%)",
   "bc-dim": "hsl(233, 33%, 16%)",
-  "bright": "#fff",
-  "dim": "hsl(233, 13%, 60%)",
-  "hover-bg": "hsl(233, 43%, 10%)",
+  "bc-light": "#dfdfdf",
+  "box-shadow": "hsla(0,0,0,0.2)",
+  "dim": "hsl(240, 5%, 75%)",
+  "hover-bg": "hsla(233, 88%, 90%, 0.2)",
   "input-bc": "hsl(233, 22%, 33%)",
   "input-bc-hover": "hsl(233, 22%, 40%)",
-  "txt": "hsl(233, 13%, 85%)",
+  "link": "hsl(233, 88%, 82%)",
+  "txt": "hsl(0, 0%, 100%)",
 }
 `;
 
 exports[`Module: Themes has a light theme 1`] = `
 Object {
-  "app-bg": "#fff",
+  "app-bg": "#f5f5f5",
   "app-bg-alpha": "hsla(233, 0%, 0%, 5%)",
-  "app-bg-light": "hsla(233, 0%, 0%, 5%)",
-  "app-fg": "#f3f3f3",
+  "app-bg-light": "#fff",
+  "app-fg": "hsl(0,0%,92%)",
   "bc": "#ddd",
-  "bc-dim": "#eee",
-  "bright": "#000",
-  "dim": "#666",
-  "hover-bg": "#f3f3f3",
+  "bc-dim": "#cdcbcb",
+  "bc-light": "#dfdfdf",
+  "box-shadow": "hsla(0,0,80%,0.2)",
+  "dim": "#3b3b3b",
+  "hover-bg": "hsla(233, 88%, 90%, 0.2)",
   "input-bc": "hsl(233, 22%, 67%)",
   "input-bc-hover": "hsl(233, 22%, 40%)",
-  "txt": "#333",
+  "link": "hsl(233, 88%, 57%)",
+  "txt": "#000",
 }
 `;

--- a/test/unit/specs/store/__snapshots__/themes.spec.js.snap
+++ b/test/unit/specs/store/__snapshots__/themes.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Module: Themes has a dark theme 1`] = `
 Object {
   "app-bg": "hsl(233, 36%, 13%)",
   "app-bg-alpha": "hsla(233, 36%, 13%, 95%)",
+  "app-bg-light": "hsla(233, 36%, 13%, 95%)",
   "app-fg": "hsl(233, 33%, 16%)",
   "bc": "hsl(233, 22%, 23%)",
   "bc-dim": "hsl(233, 33%, 16%)",
@@ -20,6 +21,7 @@ exports[`Module: Themes has a light theme 1`] = `
 Object {
   "app-bg": "#fff",
   "app-bg-alpha": "hsla(233, 0%, 0%, 5%)",
+  "app-bg-light": "hsla(233, 0%, 0%, 5%)",
   "app-fg": "#f3f3f3",
   "bc": "#ddd",
   "bc-dim": "#eee",


### PR DESCRIPTION
Closes #874 

Originally found components like this:
![screenshot 2018-06-25 12 31 32](https://user-images.githubusercontent.com/964052/41849077-f6cc456a-787f-11e8-899f-b1ea80a82d9e.png)
![screenshot 2018-06-25 12 31 38](https://user-images.githubusercontent.com/964052/41849083-f9c7df68-787f-11e8-878b-82c5f3e0eba5.png)
![screenshot 2018-06-25 13 51 01](https://user-images.githubusercontent.com/964052/41849103-0a68ec36-7880-11e8-90d8-2232996dbba0.png)
![screenshot 2018-06-25 13 50 54](https://user-images.githubusercontent.com/964052/41849100-082e4970-7880-11e8-967f-69e05cc68cc5.png)
(notice dark theme has mismatched backgrounds as well)

saw that `app-bg-light` was being referenced on all of these components but that `app-bg-light` was not present in the theme json objects. Added `app-bg-light` by mimicking `app-bg-alpha` to produce these:
![screenshot 2018-06-25 13 51 37](https://user-images.githubusercontent.com/964052/41849169-44657f12-7880-11e8-9c9c-b79a7b48e19a.png)
![screenshot 2018-06-25 13 51 30](https://user-images.githubusercontent.com/964052/41849167-421d25de-7880-11e8-9116-e3e812fc561f.png)
![screenshot 2018-06-25 13 51 57](https://user-images.githubusercontent.com/964052/41849185-4aeb358e-7880-11e8-9c77-141727657d45.png)
![screenshot 2018-06-25 13 51 51](https://user-images.githubusercontent.com/964052/41849180-490ce5c8-7880-11e8-9d98-204a70479675.png)

Was this the originally intended effect or something else?
