### PR TITLE
cached validators #451

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Removed COSMOS_MOCKED flag @faboweb
 * Improved readability and accessibility @jolesbi
 * Significant style / UI updates @jolesbi
+* Doesn't show loading screen when validators are still stored @okwme
 
 ### Fixed
 

--- a/app/src/renderer/components/staking/PageStaking.vue
+++ b/app/src/renderer/components/staking/PageStaking.vue
@@ -9,7 +9,7 @@ page(title='Staking')
   modal-search(type="delegates" v-if="somethingToSearch")
 
   .delegates-container
-    data-loading(v-if="delegates.loading")
+    data-loading(v-if="delegates.loading && delegates.delegates.length === 0")
     data-empty(v-else-if="delegates.delegates.length === 0")
     data-empty-search(v-else-if="filteredDelegates.length === 0")
     template(v-else)
@@ -41,7 +41,7 @@ import Part from "common/NiPart"
 import PanelSort from "staking/PanelSort"
 import ToolBar from "common/NiToolBar"
 export default {
-  name: "page-delegates",
+  name: "page-staking",
   components: {
     LiDelegate,
     Btn,


### PR DESCRIPTION
Closes #451

Description: stops showing the loading screen on the staking page when validators have already been loaded. (This issue highlighted the fact that polling all validators is very intense on the LCD and often overloads it: https://github.com/cosmos/voyager/issues/879)

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
