### PR TITLE
fixed timing issue on launch for dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fixed theme bg bug @okwme
 * Fixed sorting bug on staking page @okwme
 * Fixed missing node-ip in connection indicator @faboweb
+* Launch sequence for dev improved @okwme
 
 ### Added
 

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -141,18 +141,17 @@ function createWindow() {
   mainWindow.once("ready-to-show", () => {
     setTimeout(() => {
       mainWindow.show()
+      if (DEV || JSON.parse(process.env.COSMOS_DEVTOOLS || "false")) {
+        mainWindow.webContents.openDevTools()
+      }
+      if (DEV) {
+        mainWindow.maximize()
+      }
     }, 300)
   })
 
   // start vue app
   mainWindow.loadURL(winURL + "?lcd_port=" + LCD_PORT)
-
-  if (DEV || JSON.parse(process.env.COSMOS_DEVTOOLS || "false")) {
-    mainWindow.webContents.openDevTools()
-  }
-  if (DEV) {
-    mainWindow.maximize()
-  }
 
   mainWindow.on("closed", shutdown)
 


### PR DESCRIPTION
Closes #NA

Description: when launching on dev the full screen / show dev panel command happens before the app is shown. This results in the toolbar at the top being hidden behind the dev console. Re-ordering the sequence fixes it.
