### PR TITLE
Hide block subscription errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Doesn't show loading screen when validators are still stored @okwme
 * Improved CI @faboweb
 * Search bar fixed to top @okwme
+* Hide block subscription errors @mappum
 
 ### Fixed
 

--- a/app/src/renderer/vuex/modules/blockchain.js
+++ b/app/src/renderer/vuex/modules/blockchain.js
@@ -148,10 +148,7 @@ export default ({ commit, node }) => {
 
       function error(err) {
         state.subscription = false
-        commit("notifyError", {
-          title: `Error subscribing to new blocks`,
-          body: err.message
-        })
+        console.error(`Error subscribing to new blocks: ${err.message}`)
       }
 
       node.rpc.status((err, status) => {


### PR DESCRIPTION
Closes #844 

Description:

We sometimes can't subscribe to blocks (e.g. when we can't connect to a node), and we shouldn't spam the user with errors that don't really make sense to them. This just switches from an error notification to `console.error`.
