### PR TITLE
send w an empty wallet bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fixed missing node-ip in connection indicator @faboweb
 * Launch sequence for dev improved @okwme
 * E2E test maybe fix @okwme
+* Send with an empty wallet bug @okwme
 
 ### Added
 

--- a/app/src/renderer/components/common/TmDataEmptyTx.vue
+++ b/app/src/renderer/components/common/TmDataEmptyTx.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 tm-data-msg(icon="info_outline")
   div(slot="title") No Transaction History
-  div(slot="subtitle") Looks like you haven't sent or received any transactions yet. Head over to #[router-link(:to="{ name: 'send' }") Send] to make your first transaction!
+  div(slot="subtitle") Looks like you haven't sent or received any transactions yet. Head over to your #[router-link(:to="{ name: 'balances' }") Wallet] to make your first transaction!
 </template>
 
 <script>

--- a/test/unit/specs/components/common/__snapshots__/TmDataEmptyTx.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmDataEmptyTx.spec.js.snap
@@ -13,9 +13,9 @@ exports[`TmDataEmptyTx has the expected html structure 1`] = `
 </div>
 <div class=\\"tm-data-msg__subtitle\\">
    <div>
-      Looks like you haven't sent or received any transactions yet. Head over to 
+      Looks like you haven't sent or received any transactions yet. Head over to your 
       <router-link to=\\"[object Object]\\">
-         Send
+         Wallet
       </router-link>
 to make your first transaction!
    </div>


### PR DESCRIPTION
Closes #922 

Description: Simple fix. The send link wouldn't work anyway because there was no denomination specified. Linking to wallet makes more sense and avoids getting to the send screen with no denom.
