### PR TITLE
Fabo/ni to tm class rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Staking tokens showing NaN @faboweb
 * Staking page showing old shares after bonding @faboweb
 * Made linting work on Windows. @NodeGuy
-* Renamed some ni- class identifiers to tm- @faboweb
+* Renamed some ni- class identifiers to tm- to be consistent @faboweb
 
 ## [0.7.1] - 2018-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Staking tokens showing NaN @faboweb
 * Staking page showing old shares after bonding @faboweb
 * Made linting work on Windows. @NodeGuy
+* Renamed some ni- class identifiers to tm- @faboweb
 
 ## [0.7.1] - 2018-07-04
 

--- a/app/src/renderer/components/common/TmModalNoNodes.vue
+++ b/app/src/renderer/components/common/TmModalNoNodes.vue
@@ -1,17 +1,17 @@
 <template lang="pug">
-.ni-modal-error__wrapper
-  .ni-modal-error
-    .ni-modal-error__icon: i.material-icons sync_problem
-    .ni-modal-error__title No nodes found
-    .ni-modal-error__body All known nodes are offline or incompatible. You can retry to connect or switch to a demo connection so you can try out Voyager.
-    .ni-modal-error__footer
-      tm-btn#ni-modal-error__btn-retry(
+.tm-modal-error__wrapper
+  .tm-modal-error
+    .tm-modal-error__icon: i.material-icons sync_problem
+    .tm-modal-error__title No nodes found
+    .tm-modal-error__body All known nodes are offline or incompatible. You can retry to connect or switch to a demo connection so you can try out Voyager.
+    .tm-modal-error__footer
+      tm-btn#tm-modal-error__btn-retry(
         size="lg"
         icon="autorenew"
         color="primary"
         value="Retry Connection"
         @click.native="retry")
-      tm-btn#ni-modal-error__btn-mock(
+      tm-btn#tm-modal-error__btn-mock(
         size="lg"
         icon="pageview"
         value="Try Demo"
@@ -40,7 +40,7 @@ export default {
 <style lang="stylus">
 @import '~variables'
 
-.ni-modal-error__wrapper
+.tm-modal-error__wrapper
   position absolute
   top 0
   left 0
@@ -53,11 +53,11 @@ export default {
   align-items center
   justify-content center
 
-.ni-modal-error
+.tm-modal-error
   padding 1.5rem
   max-width 40rem
 
-.ni-modal-error__icon
+.tm-modal-error__icon
   position fixed
   top 0
   left 0
@@ -68,19 +68,19 @@ export default {
     line-height 1
     color var(--bc-dim)
 
-.ni-modal-error__title
+.tm-modal-error__title
   font-size h1
   font-weight 500
   line-height 1
   margin-bottom 1.5rem
 
-.ni-modal-error__body
+.tm-modal-error__body
   font-size lg
   color var(--dim)
   margin-bottom 3rem
 
-.ni-modal-error__footer
-  .ni-btn
+.tm-modal-error__footer
+  .tm-btn
     width 100%
     margin-right 1.5rem
     margin-bottom 1rem
@@ -90,15 +90,15 @@ export default {
       margin-bottom 0
 
 @media screen and (min-width: 768px)
-  .ni-modal-error__icon i.material-icons
+  .tm-modal-error__icon i.material-icons
     font-size 20vw + 20vh
 
-  .ni-modal-error__body
+  .tm-modal-error__body
     margin-bottom 4.5rem
 
-  .ni-modal-error__footer
+  .tm-modal-error__footer
     min-width 31rem
 
-  .ni-modal-error__footer .ni-btn
+  .tm-modal-error__footer .tm-btn
     margin-bottom 0
 </style>

--- a/app/src/renderer/components/common/TmModalNodeHalted.vue
+++ b/app/src/renderer/components/common/TmModalNodeHalted.vue
@@ -1,17 +1,17 @@
 <template lang="pug">
-.ni-modal-error__wrapper
-  .ni-modal-error
-    .ni-modal-error__icon: i.material-icons sync_problem
-    .ni-modal-error__title Node has halted
-    .ni-modal-error__body The node your are connected to appears to have halted. You can try to connect to another node or switch to a demo connection so you can try out Voyager.
-    .ni-modal-error__footer
-      tm-btn#ni-modal-error__btn-retry(
+.tm-modal-error__wrapper
+  .tm-modal-error
+    .tm-modal-error__icon: i.material-icons sync_problem
+    .tm-modal-error__title Node has halted
+    .tm-modal-error__body The node your are connected to appears to have halted. You can try to connect to another node or switch to a demo connection so you can try out Voyager.
+    .tm-modal-error__footer
+      tm-btn#tm-modal-error__btn-retry(
         size="lg"
         icon="autorenew"
         color="primary"
         value="Switch Node"
         @click.native="switchNode")
-      tm-btn#ni-modal-error__btn-mock(
+      tm-btn#tm-modal-error__btn-mock(
         size="lg"
         icon="pageview"
         value="Try Demo"
@@ -40,7 +40,7 @@ export default {
 <style lang="stylus">
 @import '~variables'
 
-.ni-modal-error__wrapper
+.tm-modal-error__wrapper
   position absolute
   top 0
   left 0
@@ -53,11 +53,11 @@ export default {
   align-items center
   justify-content center
 
-.ni-modal-error
+.tm-modal-error
   padding 1.5rem
   max-width 40rem
 
-.ni-modal-error__icon
+.tm-modal-error__icon
   position fixed
   top 0
   left 0
@@ -68,19 +68,19 @@ export default {
     line-height 1
     color var(--bc-dim)
 
-.ni-modal-error__title
+.tm-modal-error__title
   font-size h1
   font-weight 500
   line-height 1
   margin-bottom 1.5rem
 
-.ni-modal-error__body
+.tm-modal-error__body
   font-size lg
   color var(--dim)
   margin-bottom 3rem
 
-.ni-modal-error__footer
-  .ni-btn
+.tm-modal-error__footer
+  .tm-btn
     width 100%
     margin-right 1.5rem
     margin-bottom 1rem
@@ -90,15 +90,15 @@ export default {
       margin-bottom 0
 
 @media screen and (min-width: 768px)
-  .ni-modal-error__icon i.material-icons
+  .tm-modal-error__icon i.material-icons
     font-size 20vw + 20vh
 
-  .ni-modal-error__body
+  .tm-modal-error__body
     margin-bottom 4.5rem
 
-  .ni-modal-error__footer
+  .tm-modal-error__footer
     min-width 31rem
 
-  .ni-modal-error__footer .ni-btn
+  .tm-modal-error__footer .tm-btn
     margin-bottom 0
 </style>

--- a/app/src/renderer/styles/app.styl
+++ b/app/src/renderer/styles/app.styl
@@ -60,10 +60,10 @@ a
 .tm-field
   border-radius 2px!important
 
-input.ni-field
+input.tm-field
   height inherit !important
 
-.ni-select .ni-field-select-addon
+.tm-select .tm-field-select-addon
   height 100% !important
 
 #app-content

--- a/test/unit/specs/components/common/__snapshots__/TmModalNoNodes.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmModalNoNodes.spec.js.snap
@@ -2,13 +2,13 @@
 
 exports[`TmModalNoNodes has the expected html structure 1`] = `
 <div
-  class="ni-modal-error__wrapper"
+  class="tm-modal-error__wrapper"
 >
   <div
-    class="ni-modal-error"
+    class="tm-modal-error"
   >
     <div
-      class="ni-modal-error__icon"
+      class="tm-modal-error__icon"
     >
       <i
         class="material-icons"
@@ -17,21 +17,21 @@ exports[`TmModalNoNodes has the expected html structure 1`] = `
       </i>
     </div>
     <div
-      class="ni-modal-error__title"
+      class="tm-modal-error__title"
     >
       No nodes found
     </div>
     <div
-      class="ni-modal-error__body"
+      class="tm-modal-error__body"
     >
       All known nodes are offline or incompatible. You can retry to connect or switch to a demo connection so you can try out Voyager.
     </div>
     <div
-      class="ni-modal-error__footer"
+      class="tm-modal-error__footer"
     >
       <button
         class="tm-btn"
-        id="ni-modal-error__btn-retry"
+        id="tm-modal-error__btn-retry"
       >
         <span
           class="tm-btn__container tm-btn--size-lg tm-btn--primary"
@@ -52,7 +52,7 @@ exports[`TmModalNoNodes has the expected html structure 1`] = `
       </button>
       <button
         class="tm-btn"
-        id="ni-modal-error__btn-mock"
+        id="tm-modal-error__btn-mock"
       >
         <span
           class="tm-btn__container tm-btn--size-lg"

--- a/test/unit/specs/components/common/__snapshots__/TmModalNodeHalted.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmModalNodeHalted.spec.js.snap
@@ -2,13 +2,13 @@
 
 exports[`TmModalNodeHalted has the expected html structure 1`] = `
 <div
-  class="ni-modal-error__wrapper"
+  class="tm-modal-error__wrapper"
 >
   <div
-    class="ni-modal-error"
+    class="tm-modal-error"
   >
     <div
-      class="ni-modal-error__icon"
+      class="tm-modal-error__icon"
     >
       <i
         class="material-icons"
@@ -17,21 +17,21 @@ exports[`TmModalNodeHalted has the expected html structure 1`] = `
       </i>
     </div>
     <div
-      class="ni-modal-error__title"
+      class="tm-modal-error__title"
     >
       Node has halted
     </div>
     <div
-      class="ni-modal-error__body"
+      class="tm-modal-error__body"
     >
       The node your are connected to appears to have halted. You can try to connect to another node or switch to a demo connection so you can try out Voyager.
     </div>
     <div
-      class="ni-modal-error__footer"
+      class="tm-modal-error__footer"
     >
       <button
         class="tm-btn"
-        id="ni-modal-error__btn-retry"
+        id="tm-modal-error__btn-retry"
       >
         <span
           class="tm-btn__container tm-btn--size-lg tm-btn--primary"
@@ -52,7 +52,7 @@ exports[`TmModalNodeHalted has the expected html structure 1`] = `
       </button>
       <button
         class="tm-btn"
-        id="ni-modal-error__btn-mock"
+        id="tm-modal-error__btn-mock"
       >
         <span
           class="tm-btn__container tm-btn--size-lg"


### PR DESCRIPTION
Description:

Some classes still had the `ni-` namespace. Changed it to the new namespace `tm-`.

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
