### PR TITLE
Fabo/fix blockexplorer not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* fixed block explorer always showing "syncing" @faboweb
+
 ## [0.8.2] - 2018-07-23
 
 ### Fixed

--- a/app/src/renderer/main.js
+++ b/app/src/renderer/main.js
@@ -81,7 +81,7 @@ async function main() {
   ipcRenderer.on("connected", (event, nodeIP) => {
     node.rpcConnect(nodeIP)
     store.dispatch("rpcSubscribe")
-    // store.dispatch("subscribeToBlocks")
+    store.dispatch("subscribeToBlocks")
 
     if (firstStart) {
       store.dispatch("showInitialScreen")


### PR DESCRIPTION
Description:

Block explorer always shows "syncing". This was caused by me trying to fix #980 

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
