### PR TITLE
unified button styles, light theme fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+* button styling @jolesbi
 * Switched to Gaia-7004 @faboweb
 * showing warning about out of range of atoms in bonding UI only once on top and renaming it @faboweb
 
 ### Fixed
 
+* broken styles in light theme @jolesbi
 * slider in staking UI @faboweb
 * error with empty accounts @faboweb
 

--- a/app/src/renderer/styles/app.styl
+++ b/app/src/renderer/styles/app.styl
@@ -67,13 +67,18 @@ a
 
 // these styles should live in tendermint/ui
 .tm-field
-  border-radius 2px!important
+  border-radius 0.25rem !important
 
 input.tm-field
   height inherit !important
 
+.tm-select
+  .tm-field
+    border 1px solid var(--bc, #ddd);
+
 .tm-select .tm-field-select-addon
   height 100% !important
+  border-left 1px solid var(--bc, #ddd);
 
 .tm-part-header
   border 1px solid var(--bc-dim)
@@ -81,14 +86,20 @@ input.tm-field
 .tm-part-main
   padding-right 0 !important
 
-  .tm-btn__container
-    margin-right 1rem
+  .tm-li-input
+    padding-right 1rem
 
 .tm-page-header-container
   min-height 5.5rem
 
 .tm-data-msg
   border 1px solid var(--bc-dim)
+
+.tm-btn__container
+  border-width 1px
+
+.tm-li-container
+  margin-right 1rem
 
 #app-content
   flex 1

--- a/app/src/renderer/styles/app.styl
+++ b/app/src/renderer/styles/app.styl
@@ -86,9 +86,6 @@ input.tm-field
 .tm-part-main
   padding-right 0 !important
 
-  .tm-li-input
-    padding-right 1rem
-
 .tm-page-header-container
   min-height 5.5rem
 

--- a/app/src/renderer/vuex/json/theme-light.json
+++ b/app/src/renderer/vuex/json/theme-light.json
@@ -1,16 +1,16 @@
 {
   "app-fg": "hsl(0,0%,92%)",
   "app-bg": "#f5f5f5",
-  "app-bg-light": "#fff",
-  "app-bg-alpha": "hsla(233, 0%, 0%, 5%)",
-  "txt": "#000",
+  "app-nav": "#ddd",
+  "tertiary": "hsl(325, 96%, 59%)",
+  "secondary": "hsl(277, 92%, 58%)",
+  "primary": "hsl(233, 88%, 57%)",
+  "link": "hsl(233, 88%, 57%)",
+  "bright": "hsl(0, 100%, 100%)",
+  "hover": "hsla(0, 0%, 0%, 0)",
+  "bright": "#000",
+  "txt": "hsl(233, 38%, 14%)",
   "dim": "#3b3b3b",
   "bc": "#ddd",
-  "bc-dim": "#cdcbcb",
-  "bc-light": "#dfdfdf",
-  "box-shadow": "hsla(0,0,80%,0.2)",
-  "hover-bg": "hsla(233, 88%, 90%, 0.2)",
-  "input-bc": "hsl(233, 22%, 67%)",
-  "input-bc-hover": "hsl(233, 22%, 40%)",
-  "link": "hsl(233, 88%, 57%)"
+  "bc-dim": "#cdcbcb"
 }

--- a/test/unit/specs/store/__snapshots__/themes.spec.js.snap
+++ b/test/unit/specs/store/__snapshots__/themes.spec.js.snap
@@ -21,18 +21,17 @@ Object {
 exports[`Module: Themes has a light theme 1`] = `
 Object {
   "app-bg": "#f5f5f5",
-  "app-bg-alpha": "hsla(233, 0%, 0%, 5%)",
-  "app-bg-light": "#fff",
   "app-fg": "hsl(0,0%,92%)",
+  "app-nav": "#ddd",
   "bc": "#ddd",
   "bc-dim": "#cdcbcb",
-  "bc-light": "#dfdfdf",
-  "box-shadow": "hsla(0,0,80%,0.2)",
+  "bright": "#000",
   "dim": "#3b3b3b",
-  "hover-bg": "hsla(233, 88%, 90%, 0.2)",
-  "input-bc": "hsl(233, 22%, 67%)",
-  "input-bc-hover": "hsl(233, 22%, 40%)",
+  "hover": "hsla(0, 0%, 0%, 0)",
   "link": "hsl(233, 88%, 57%)",
-  "txt": "#000",
+  "primary": "hsl(233, 88%, 57%)",
+  "secondary": "hsl(277, 92%, 58%)",
+  "tertiary": "hsl(325, 96%, 59%)",
+  "txt": "hsl(233, 38%, 14%)",
 }
 `;


### PR DESCRIPTION
Closes #888 #1038  

- the buttons are all nice and uniform
- light theme (while still an abomination) does not have any theme "bugs"

<img width="1050" alt="screen shot 2018-07-30 at 6 06 53 pm" src="https://user-images.githubusercontent.com/6021933/43426351-68ff1e5a-9423-11e8-93a8-57a22600547c.png">
<img width="1040" alt="screen shot 2018-07-30 at 6 06 39 pm" src="https://user-images.githubusercontent.com/6021933/43426352-690e9fd8-9423-11e8-9957-476a2168ad2c.png">
