### PR TITLE
Fabo/enable staked atoms in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* enabled staked balance on PageWallet in production @faboweb
+
 ## [0.9.3] - 2018-08-02
 
 ### Fixed

--- a/app/src/renderer/components/wallet/PageWallet.vue
+++ b/app/src/renderer/components/wallet/PageWallet.vue
@@ -35,7 +35,7 @@ tm-page(title='Wallet')
       :dd="i.amount"
       :to="{name: 'send', params: {denom: i.denom}}")
 
-  tm-part#part-staked-balances(v-if="config.devMode" title="Staked Balances")
+  tm-part#part-staked-balances(title="Staked Balances")
     tm-list-item(
       btn="Stake"
       :dt="stakingDenom"


### PR DESCRIPTION
The staked balance doesn't show in production:
![Uploading image.png…]()
