### PR TITLE
Tell the main process when we're mocked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * testnets not properly available after download @faboweb
+* Tell the main process when we switch to the mock network. @NodeGuy
 
 ## [0.9.3] - 2018-08-02
 

--- a/app/src/renderer/vuex/modules/node.js
+++ b/app/src/renderer/vuex/modules/node.js
@@ -156,6 +156,9 @@ export default function({ node }) {
     async setMockedConnector({ state, dispatch, commit }, mocked) {
       state.mocked = mocked
 
+      // Tell the main process our status in case of reload.
+      ipcRenderer.send(`mocked`, mocked)
+
       // IDEA let's have an event 'networkSwitched' and bundle those action under this one
       // remove blocks from block explorer as it should not show blocks of another network
       commit("setBlocks", [])


### PR DESCRIPTION
Closes #948

Description:

It's now possible to reload after switching to the mock network.

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
