### PR TITLE
Billy/1096 votes sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * testnets not properly available after download @faboweb
 * Tell the main process when we switch to the mock network. @NodeGuy
 * improved tooltip styling @jolesbi
+* Sort validators by "Your Votes" fixed @okwme
 
 ## [0.9.3] - 2018-08-02
 

--- a/app/src/renderer/components/staking/PageStaking.vue
+++ b/app/src/renderer/components/staking/PageStaking.vue
@@ -84,12 +84,6 @@ export default {
         v.percent_of_vote = num.percent(v.voting_power / this.vpTotal)
         v.your_vote = this.num.prettyInt(this.committedDelegations[v.id])
       })
-      console.log(
-        this.delegates.delegates,
-        [this.sort.property, "small_moniker"],
-        [this.sort.order, "asc"]
-      )
-      console.log(this.delegates.delegates)
       let delegates = orderBy(
         this.delegates.delegates,
         [this.sort.property, "small_moniker"],

--- a/app/src/renderer/components/staking/PageStaking.vue
+++ b/app/src/renderer/components/staking/PageStaking.vue
@@ -14,7 +14,7 @@ tm-page(title='Staking')
     data-empty-search(v-else-if="filteredDelegates.length === 0")
     template(v-else)
       panel-sort(:sort='sort')
-      li-delegate(v-for='i in enrichedAndFilteredDelegates' :key='i.id' :delegate='i')
+      li-delegate(v-for='i in filteredDelegates' :key='i.id' :delegate='i')
 
   .fixed-button-bar(v-if="!delegates.loading")
     template(v-if="userCanDelegate")
@@ -76,20 +76,20 @@ export default {
         .slice(0, 100)
         .reduce((sum, v) => sum + v.voting_power, 0)
     },
-    enrichedAndFilteredDelegates() {
-      return this.filteredDelegates.map(d =>
-        Object.assign({}, d, {
-          your_votes: this.num.prettyInt(this.committedDelegations[d.id])
-        })
-      )
-    },
     filteredDelegates() {
       let query = this.filters.delegates.search.query || ""
 
       forEach(this.delegates.delegates, v => {
         v.small_moniker = v.moniker.toLowerCase()
         v.percent_of_vote = num.percent(v.voting_power / this.vpTotal)
+        v.your_vote = this.num.prettyInt(this.committedDelegations[v.id])
       })
+      console.log(
+        this.delegates.delegates,
+        [this.sort.property, "small_moniker"],
+        [this.sort.order, "asc"]
+      )
+      console.log(this.delegates.delegates)
       let delegates = orderBy(
         this.delegates.delegates,
         [this.sort.property, "small_moniker"],

--- a/app/src/renderer/components/staking/PageStaking.vue
+++ b/app/src/renderer/components/staking/PageStaking.vue
@@ -11,10 +11,10 @@ tm-page(title='Staking')
   .delegates-container
     tm-data-loading(v-if="delegates.loading && delegates.delegates.length === 0")
     tm-data-empty(v-else-if="delegates.delegates.length === 0")
-    data-empty-search(v-else-if="filteredDelegates.length === 0")
+    data-empty-search(v-else-if="sortedFilteredEnrichedDelegates.length === 0")
     template(v-else)
       panel-sort(:sort='sort')
-      li-delegate(v-for='i in filteredDelegates' :key='i.id' :delegate='i')
+      li-delegate(v-for='i in sortedFilteredEnrichedDelegates' :key='i.id' :delegate='i')
 
   .fixed-button-bar(v-if="!delegates.loading")
     template(v-if="userCanDelegate")
@@ -67,7 +67,7 @@ export default {
     },
     vpTotal() {
       return this.delegates.delegates
-        .slice()
+        .slice(0)
         .map(v => {
           v.voting_power = v.voting_power ? parseInt(v.voting_power) : 0
           return v
@@ -76,26 +76,29 @@ export default {
         .slice(0, 100)
         .reduce((sum, v) => sum + v.voting_power, 0)
     },
-    filteredDelegates() {
+    enrichedDelegates() {
+      return !this.somethingToSearch
+        ? []
+        : this.delegates.delegates.map(v => {
+            v.small_moniker = v.moniker.toLowerCase()
+            v.percent_of_vote = num.percent(v.voting_power / this.vpTotal)
+            v.your_votes = this.num.prettyInt(this.committedDelegations[v.id])
+            return v
+          })
+    },
+    sortedFilteredEnrichedDelegates() {
       let query = this.filters.delegates.search.query || ""
-
-      forEach(this.delegates.delegates, v => {
-        v.small_moniker = v.moniker.toLowerCase()
-        v.percent_of_vote = num.percent(v.voting_power / this.vpTotal)
-        v.your_vote = this.num.prettyInt(this.committedDelegations[v.id])
-      })
-      let delegates = orderBy(
-        this.delegates.delegates,
+      let sortedEnrichedDelegates = orderBy(
+        this.enrichedDelegates.slice(0),
         [this.sort.property, "small_moniker"],
         [this.sort.order, "asc"]
       )
-
       if (this.filters.delegates.search.visible) {
-        return delegates.filter(i =>
+        return sortedEnrichedDelegates.filter(i =>
           includes(JSON.stringify(i).toLowerCase(), query.toLowerCase())
         )
       } else {
-        return delegates
+        return sortedEnrichedDelegates
       }
     },
     userCanDelegate() {

--- a/test/unit/specs/components/staking/PageStaking.spec.js
+++ b/test/unit/specs/components/staking/PageStaking.spec.js
@@ -44,16 +44,16 @@ describe("PageStaking", () => {
     wrapper.vm.sort.property = "owner"
     wrapper.vm.sort.order = "desc"
 
-    expect(wrapper.vm.filteredDelegates.map(x => x.owner)).toEqual(
-      lcdClientMock.validators
-    )
+    expect(
+      wrapper.vm.sortedFilteredEnrichedDelegates.map(x => x.owner)
+    ).toEqual(lcdClientMock.validators)
 
     wrapper.vm.sort.property = "owner"
     wrapper.vm.sort.order = "asc"
 
-    expect(wrapper.vm.filteredDelegates.map(x => x.owner)).toEqual(
-      lcdClientMock.validators.reverse()
-    )
+    expect(
+      wrapper.vm.sortedFilteredEnrichedDelegates.map(x => x.owner)
+    ).toEqual(lcdClientMock.validators.reverse())
   })
 
   it("should filter the delegates", () => {
@@ -62,18 +62,18 @@ describe("PageStaking", () => {
       "delegates",
       lcdClientMock.validators[2].substr(20, 26)
     ])
-    expect(wrapper.vm.filteredDelegates.map(x => x.owner)).toEqual([
-      lcdClientMock.validators[2]
-    ])
+    expect(
+      wrapper.vm.sortedFilteredEnrichedDelegates.map(x => x.owner)
+    ).toEqual([lcdClientMock.validators[2]])
     wrapper.update()
     expect(wrapper.vm.$el).toMatchSnapshot()
     store.commit("setSearchQuery", [
       "delegates",
       lcdClientMock.validators[1].substr(20, 26)
     ])
-    expect(wrapper.vm.filteredDelegates.map(x => x.owner)).toEqual([
-      lcdClientMock.validators[1]
-    ])
+    expect(
+      wrapper.vm.sortedFilteredEnrichedDelegates.map(x => x.owner)
+    ).toEqual([lcdClientMock.validators[1]])
   })
 
   it("should show the amount of selected delegates", () => {


### PR DESCRIPTION
Closes #1096 

Description: Sorting by "your votes" didn't work. This is because they are added after the sorting mechanism occurs. Actually they are the only thing that occurs in `enrichedAndFilteredData` as opposed to `filteredDelegates`. 

I couldn't see a reason why they should be calculated in their own computed value. If I'm missing something we'll need another solution.
