### PR TITLE
automatic release created for v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.9.4] - 2018-08-08
+
 ### Changed
 
 * removed light theme option from preferences page @jolesbi

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cosmos-voyager",
   "productName": "Cosmos Voyager",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Voyager is an electron-based user interface for the Cosmos Network.",
   "author": "All In Bits, Inc <hello@tendermint.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Changed

* removed light theme option from preferences page @jolesbi
* enabled staked balance on PageWallet in production @faboweb
* removed unused xmlhttprequest dependency @faboweb

### Added

* storing balance, tx history and delegations locally to serve an old state faster @faboweb
* added error message for missing network config @faboweb

### Fixed

* testnets not properly available after download @faboweb
* Tell the main process when we switch to the mock network. @NodeGuy
* improved tooltip styling @jolesbi
* Overflow bonding bar bug @okwme
