### PR TITLE
automatic release created for v0.9.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,15 +140,27 @@ workflows:
 
   gaia-test-and-publish:
     jobs:
-      - changelogUpdated
+      - changelogUpdated:
+          filters:
+            branches:
+              ignore: release
 
-      - buildGaia
+      - buildGaia:
+          filters:
+            branches:
+              ignore: release
 
-      - testUnit
+      - testUnit:
+          filters:
+            branches:
+              ignore: release
 
       - testE2e:
           requires:
             - buildGaia
+          filters:
+            branches:
+              ignore: release
 
       - publish:
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.9.5] - 2018-08-19
+
 ### Changed
 
 * cache per network to not have side effects between networks @faboweb

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cosmos-voyager",
   "productName": "Cosmos Voyager",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Voyager is an electron-based user interface for the Cosmos Network.",
   "author": "All In Bits, Inc <hello@tendermint.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Changed

* cache per network to not have side effects between networks @faboweb
* publish script on CI now requires all tests to pass, so we are sure that the published Version runs @ƒaboweb
* disable interaction buttons if not connected to the network, so user do not expect working interaction @faboweb
* using a variable for determining staking denomination @jbibla
* changed ATOM to bondingDenom getter @okwme
* more bondingDenom and copy updates @jbibla

### Fixed

* now resetting most store information on signing out to not have side effects between sessions @faboweb
* import seed focus bug @okwme
* fixed trying to subscribe to transaction rpc events multiple times (prevent unexpected side effects doing so) @faboweb
