### PR TITLE
CircleCI: Don't run tests when pushing to `release`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,15 +140,27 @@ workflows:
 
   gaia-test-and-publish:
     jobs:
-      - changelogUpdated
+      - changelogUpdated:
+          filters:
+            branches:
+              ignore: release
 
-      - buildGaia
+      - buildGaia:
+          filters:
+            branches:
+              ignore: release
 
-      - testUnit
+      - testUnit:
+          filters:
+            branches:
+              ignore: release
 
       - testE2e:
           requires:
             - buildGaia
+          filters:
+            branches:
+              ignore: release
 
       - publish:
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * now resetting most store information on signing out to not have side effects between sessions @faboweb
 * import seed focus bug @okwme
 * fixed trying to subscribe to transaction rpc events multiple times (prevent unexpected side effects doing so) @faboweb
+* CircleCI no longer runs test during a push to `release`. @NodeGuy
 
 ## [0.9.4] - 2018-08-08
 


### PR DESCRIPTION
Closes #1114 

Description:

Pushing to `release` automatically creates a pull request which later goes through all of the regular tests.  CircleCI was testing the push to `release` unnecessarily.  This PR turns off the redundant tests.