### PR TITLE
Create Git tag during publish instead of during the release pull requ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * E2E tests not producing screenshots and not logging certain values @faboweb
 * Wallet balances updating after staking @okwme
 * Updated testnet build process @okwme
+* Release process now creates Git tag during publish. @NodeGuy
 
 ## [0.9.4] - 2018-08-08
 

--- a/tasks/publish.js
+++ b/tasks/publish.js
@@ -47,6 +47,7 @@ async function main() {
   const tag = getTag(
     JSON.parse(fs.readFileSync(path.join(__dirname, `../package.json`), "utf8"))
   )
+
   console.log("--- Releasing tag", tag, "---")
 
   await publishRelease({
@@ -61,7 +62,8 @@ async function main() {
     `https://${process.env.GIT_BOT_TOKEN}@github.com/cosmos/voyager.git`
   )
 
-  await git.push("bot", "HEAD:master")
+  await git.tag([tag])
+  await git.push("bot", "HEAD:master", { tags: true })
 
   console.log("--- Done releasing ---")
 }

--- a/tasks/releasePullRequest.js
+++ b/tasks/releasePullRequest.js
@@ -33,8 +33,6 @@ const pushCommit = async ({ token, tag, head }) => {
     __dirname + "/../CHANGELOG.md"
   ])
 
-  await git.tag([tag])
-
   // needed to authenticate properly
   await git.addRemote("bot", `https://${token}@github.com/cosmos/voyager.git`)
 


### PR DESCRIPTION
…est.

Closes #1165 

Description:

Creates a Git tag during publish instead of when creating the release pull request.  This will be fully tested only when we publish the next release.