### PR TITLE
fixed validator url leading to explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Do not try to publish a release on every push to `develop`! @NodeGuy
-* validator url leading to explorer @faboweb
+* validator url on txs leading to explorer @faboweb
 
 ## [0.10.2] - 2018-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Do not try to publish a release on every push to `develop`! @NodeGuy
+* validator url leading to explorer @faboweb
 
 ## [0.10.2] - 2018-08-29
 

--- a/app/src/renderer/components/wallet/PageTransactions.vue
+++ b/app/src/renderer/components/wallet/PageTransactions.vue
@@ -83,7 +83,7 @@ export default {
       property: "height",
       order: "desc"
     },
-    validatorURL: "/validators"
+    validatorURL: "/staking/validators"
   }),
   methods: {
     refreshTransactions() {

--- a/app/src/renderer/components/wallet/PageTransactions.vue
+++ b/app/src/renderer/components/wallet/PageTransactions.vue
@@ -83,7 +83,7 @@ export default {
       property: "height",
       order: "desc"
     },
-    validatorURL: "https://explorecosmos.network/validators"
+    validatorURL: "/validators"
   }),
   methods: {
     refreshTransactions() {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "webpack-dev-server": "2.11.2"
   },
   "dependencies": {
-    "@tendermint/ui": "0.2.22",
+    "@tendermint/ui": "0.2.23",
     "@vue/test-utils": "1.0.0-beta.11",
     "autosize": "4.0.2",
     "axios": "0.18.0",

--- a/test/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
+++ b/test/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
@@ -105,31 +105,31 @@ exports[`PageTransactions has the expected html structure 1`] = `
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="https://explorecosmos.network/validators"
+      validatorurl="/validators"
     />
     <tm-li-any-transaction
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="https://explorecosmos.network/validators"
+      validatorurl="/validators"
     />
     <tm-li-any-transaction
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="https://explorecosmos.network/validators"
+      validatorurl="/validators"
     />
     <tm-li-any-transaction
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="https://explorecosmos.network/validators"
+      validatorurl="/validators"
     />
     <tm-li-any-transaction
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="https://explorecosmos.network/validators"
+      validatorurl="/validators"
     />
     <div
       class="ps__rail-x"
@@ -303,7 +303,7 @@ exports[`PageTransactions should filter the transactions 1`] = `
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="https://explorecosmos.network/validators"
+      validatorurl="/validators"
     />
   </main>
 </div>

--- a/test/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
+++ b/test/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
@@ -105,31 +105,31 @@ exports[`PageTransactions has the expected html structure 1`] = `
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="/validators"
+      validatorurl="/staking/validators"
     />
     <tm-li-any-transaction
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="/validators"
+      validatorurl="/staking/validators"
     />
     <tm-li-any-transaction
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="/validators"
+      validatorurl="/staking/validators"
     />
     <tm-li-any-transaction
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="/validators"
+      validatorurl="/staking/validators"
     />
     <tm-li-any-transaction
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="/validators"
+      validatorurl="/staking/validators"
     />
     <div
       class="ps__rail-x"
@@ -303,7 +303,7 @@ exports[`PageTransactions should filter the transactions 1`] = `
       address="tb1d4u5zerywfjhxuc9nudvw"
       transaction="[object Object]"
       validators=""
-      validatorurl="/validators"
+      validatorurl="/staking/validators"
     />
   </main>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,9 +105,9 @@
     node-fetch "^2.1.1"
     url-template "^2.0.8"
 
-"@tendermint/ui@0.2.22":
-  version "0.2.22"
-  resolved "https://registry.yarnpkg.com/@tendermint/ui/-/ui-0.2.22.tgz#83d43154d212e8faf0ece05800d7ad5e3d3b1d9d"
+"@tendermint/ui@0.2.23":
+  version "0.2.23"
+  resolved "https://registry.yarnpkg.com/@tendermint/ui/-/ui-0.2.23.tgz#d9e817fa151f29cf477678c60caaca705dfb6a01"
   dependencies:
     axios "^0.18.0"
     cookieconsent "^3.0.6"


### PR DESCRIPTION
Description:

Now that the transactions use the vue router, the links on the staking transactions can lead to the internal validator page.

Blocked by https://github.com/tendermint/ui/pull/66

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
