### PR TITLE
new delegation window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Refactored Addressbook. @NodeGuy
 
+### Changed
+
+* Created new modal window for staking to a validator. @NodeGuy
+
 ### Fixed
 
 * Do not try to publish a release on every push to `develop`! @NodeGuy

--- a/app/src/renderer/components/staking/ModalStake.vue
+++ b/app/src/renderer/components/staking/ModalStake.vue
@@ -1,0 +1,112 @@
+<template lang="pug">
+  .modal-stake
+    .stake-header
+      img.icon(class='stake-atom' src="~assets/images/cosmos-logo.png")
+      span.tm-modal-title Stake
+
+    tm-form-group.stake-form-group(
+      :error='$v.amount.$invalid'
+      field-id='amount'
+      field-label='Amount'
+    )
+      tm-field#amount(
+        type="number"
+        v-model="amount")
+      tm-form-msg(name='Amount' type='between' :min='1' :max='maximum'
+        v-if='$v.amount.$invalid')
+
+    tm-form-group.stake-form-group(
+      field-id='to' field-label='To')
+      tm-field#to(v-model="to")
+
+    tm-form-group.stake-form-group(
+      field-id='from' field-label='From')
+      tm-field#from(
+        type="select"
+        :options="fromOptions"
+        v-model="fromIndex"
+      )
+
+    .stake-footer
+      tm-btn(
+        @click.native="onStake"
+        color="primary"
+        :disabled="$v.amount.$invalid"
+        size="lg"
+        value="Stake"
+      )
+</template>
+
+<script>
+import { between } from "vuelidate/lib/validators"
+import Modal from "common/TmModal"
+import { TmBtn, TmField, TmFormGroup, TmFormMsg } from "@tendermint/ui"
+
+export default {
+  props: [`fromOptions`, `maximum`, `to`],
+  components: {
+    Modal,
+    TmBtn,
+    TmField,
+    TmFormGroup,
+    TmFormMsg
+  },
+  data: () => ({
+    amount: 1,
+    fromIndex: 0
+  }),
+  validations() {
+    return {
+      amount: {
+        between: between(1, this.maximum)
+      }
+    }
+  },
+  methods: {
+    close() {
+      this.$emit("update:showModalStake", false)
+    },
+    onStake() {
+      this.$emit(`stake`, {
+        amount: this.amount,
+        from: this.fromOptions[this.fromIndex]
+      })
+
+      this.close()
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+@import '~variables'
+
+.modal-stake
+  background: var(--app-nav)
+  display: flex
+  flex-direction: column
+  height: 50%
+  justify-content: space-between
+  left: 50%
+  padding: 3%
+  position: fixed
+  top: 50%
+  width: 40%
+  z-index: z(modal)
+
+  .stake-header
+    align-items: center
+    display: flex
+
+    .stake-atom
+      height: 3em
+      width: 3em
+
+  .stake-form-group
+    display: block
+    padding: 0
+
+  .stake-footer
+    display: flex
+    justify-content: flex-end
+</style>

--- a/app/src/renderer/components/staking/ModalStake.vue
+++ b/app/src/renderer/components/staking/ModalStake.vue
@@ -1,24 +1,28 @@
 <template lang="pug">
   .modal-stake
+    //- Header
     .stake-header
       img.icon(class='stake-atom' src="~assets/images/cosmos-logo.png")
       span.tm-modal-title Stake
 
+    //- Amount
     tm-form-group.stake-form-group(
-      :error='$v.amount.$invalid'
       field-id='amount'
       field-label='Amount'
     )
       tm-field#amount(
+        :max="maximum"
+        :min="1"
         type="number"
+        v-focus
         v-model="amount")
-      tm-form-msg(name='Amount' type='between' :min='1' :max='maximum'
-        v-if='$v.amount.$invalid')
 
+    //- To
     tm-form-group.stake-form-group(
       field-id='to' field-label='To')
-      tm-field#to(v-model="to")
+      tm-field#to(readonly v-model="to")
 
+    //- From
     tm-form-group.stake-form-group(
       field-id='from' field-label='From')
       tm-field#from(
@@ -27,18 +31,17 @@
         v-model="fromIndex"
       )
 
+    //- Footer
     .stake-footer
       tm-btn(
         @click.native="onStake"
         color="primary"
-        :disabled="$v.amount.$invalid"
         size="lg"
         value="Stake"
       )
 </template>
 
 <script>
-import { between } from "vuelidate/lib/validators"
 import Modal from "common/TmModal"
 import { TmBtn, TmField, TmFormGroup, TmFormMsg } from "@tendermint/ui"
 
@@ -55,19 +58,12 @@ export default {
     amount: 1,
     fromIndex: 0
   }),
-  validations() {
-    return {
-      amount: {
-        between: between(1, this.maximum)
-      }
-    }
-  },
   methods: {
     close() {
       this.$emit("update:showModalStake", false)
     },
     onStake() {
-      this.$emit(`stake`, {
+      this.$emit(`submitDelegation`, {
         amount: this.amount,
         from: this.fromOptions[this.fromIndex]
       })
@@ -82,31 +78,31 @@ export default {
 @import '~variables'
 
 .modal-stake
-  background: var(--app-nav)
-  display: flex
-  flex-direction: column
-  height: 50%
-  justify-content: space-between
-  left: 50%
-  position: fixed
-  top: 50%
-  width: 40%
-  z-index: z(modal)
+  background var(--app-nav)
+  display flex
+  flex-direction column
+  height 50%
+  justify-content space-between
+  left 50%
   padding 2em
+  position fixed
+  top 50%
+  width 40%
+  z-index z(modal)
 
   .stake-header
-    align-items: center
-    display: flex
+    align-items center
+    display flex
 
     .stake-atom
-      height: 3em
-      width: 3em
+      height 3em
+      width 3em
 
   .stake-form-group
-    display: block
-    padding: 0
+    display block
+    padding 0
 
   .stake-footer
-    display: flex
-    justify-content: flex-end
+    display flex
+    justify-content flex-end
 </style>

--- a/app/src/renderer/components/staking/ModalStake.vue
+++ b/app/src/renderer/components/staking/ModalStake.vue
@@ -88,11 +88,11 @@ export default {
   height: 50%
   justify-content: space-between
   left: 50%
-  padding: 3%
   position: fixed
   top: 50%
   width: 40%
   z-index: z(modal)
+  padding 2em
 
   .stake-header
     align-items: center

--- a/app/src/renderer/components/staking/PageValidator.vue
+++ b/app/src/renderer/components/staking/PageValidator.vue
@@ -34,26 +34,56 @@ tm-page(:title='validatorTitle(this.validator)')
       tm-list-item(dt="Commission Maximum" :dd="pretty(validator.commission_max) + ' %'")
       tm-list-item(dt="Commission Change-Rate" :dd="pretty(validator.commission_change_rate) + ' %'")
       tm-list-item(dt="Commission Change Today" :dd="pretty(validator.commission_change_today) + ' %'")
+
+    modal-stake(
+      v-if="showModalStake"
+      v-on:stake="onStake"
+      :showModalStake.sync="showModalStake"
+      :fromOptions="[{ key: `My Wallet - ${this.wallet.address}`, value: 0 }]"
+      :maximum="this.totalAtoms - this.oldBondedAtoms"
+      :to="validator.owner"
+    )
+
+    tm-btn(
+      @click.native="showModalStake = true"
+      color="primary"
+      value="Stake"
+    )
 </template>
 
 <script>
 import { mapGetters } from "vuex"
-import { TmListItem, TmPage, TmPart, TmToolBar } from "@tendermint/ui"
+import { TmBtn, TmListItem, TmPage, TmPart, TmToolBar } from "@tendermint/ui"
 import { TmDataError } from "common/TmDataError"
+import ModalStake from "staking/ModalStake"
 import numeral from "numeral"
 import AnchorCopy from "common/AnchorCopy"
 export default {
   name: "page-validator",
   components: {
     AnchorCopy,
+    "modal-stake": ModalStake,
+    TmBtn,
     TmListItem,
     TmPage,
     TmPart,
     TmToolBar,
     TmDataError
   },
+  data: () => ({
+    showModalStake: false
+  }),
   computed: {
-    ...mapGetters(["delegates", "config", "keybase"]),
+    ...mapGetters([
+      `bondingDenom`,
+      "delegates",
+      `delegation`,
+      "config",
+      "keybase",
+      `oldBondedAtoms`,
+      `totalAtoms`,
+      `wallet`
+    ]),
     validator() {
       let validator = this.delegates.delegates.find(
         v => this.$route.params.validator === v.owner
@@ -68,6 +98,45 @@ export default {
     }
   },
   methods: {
+    // submit a delegation
+    async onStake({ amount }) {
+      const to = this.validator.owner
+
+      const currentlyDelegated =
+        parseInt(this.delegation.committedDelegates[to]) || 0
+
+      const delegation = [
+        {
+          atoms: currentlyDelegated + amount,
+          delegate: { owner: to }
+        }
+      ]
+
+      try {
+        await this.$store.dispatch("submitDelegation", delegation)
+
+        this.$store.commit("notify", {
+          title: "Successful Staking!",
+          body: `You have successfully staked your ${this.bondingDenom}s.`
+        })
+      } catch ({ message }) {
+        let errData = message.split("\n")[5]
+
+        if (errData) {
+          let parsedErr = errData.split('"')[1]
+
+          this.$store.commit("notifyError", {
+            title: `Error While Staking ${this.bondingDenom}s`,
+            body: parsedErr[0].toUpperCase() + parsedErr.slice(1)
+          })
+        } else {
+          this.$store.commit("notifyError", {
+            title: `Error While Staking ${this.bondingDenom}s`,
+            body: message
+          })
+        }
+      }
+    },
     validatorTitle(validator) {
       if (!validator) return "Validator Not Found"
       let title
@@ -91,9 +160,9 @@ export default {
 <style lang="stylus">
 @media screen and (min-width: 640px)
   #validator-profile .tm-part-main
-    display flex
-    flex-flow row-reverse nowrap
+    display: flex
+    flex-flow: row-reverse nowrap
 
     .list-items
-      flex 1
+      flex: 1
 </style>

--- a/app/src/renderer/components/staking/PageValidator.vue
+++ b/app/src/renderer/components/staking/PageValidator.vue
@@ -160,9 +160,9 @@ export default {
 <style lang="stylus">
 @media screen and (min-width: 640px)
   #validator-profile .tm-part-main
-    display: flex
-    flex-flow: row-reverse nowrap
+    display flex
+    flex-flow row-reverse nowrap
 
     .list-items
-      flex: 1
+      flex 1
 </style>

--- a/app/src/renderer/main.js
+++ b/app/src/renderer/main.js
@@ -39,6 +39,13 @@ Vue.use(Router)
 Vue.use(Tooltip, { delay: 1 })
 Vue.use(Vuelidate)
 
+// directive to focus form fields
+Vue.directive("focus", {
+  inserted: function(el) {
+    el.focus()
+  }
+})
+
 async function main() {
   let lcdPort = getQueryParameter("lcd_port")
   console.log("Expecting lcd-server on port: " + lcdPort)

--- a/test/unit/specs/components/staking/ModalStake.spec.js
+++ b/test/unit/specs/components/staking/ModalStake.spec.js
@@ -31,15 +31,6 @@ test(`display the 'To' address`, () => {
   )
 })
 
-test(`an error message is displayed if amount exceeds the maximum`, () => {
-  const wrapper = Wrapper()
-  wrapper.setData({ amount: 200 })
-
-  expect(wrapper.text().includes(`Amount must be between 1 and 100`)).toEqual(
-    true
-  )
-})
-
 test(`Stake button emits stake and close signals`, () => {
   const wrapper = Wrapper()
   wrapper.setData({ amount: 50 })
@@ -47,7 +38,7 @@ test(`Stake button emits stake and close signals`, () => {
 
   expect(wrapper.emittedByOrder()).toEqual([
     {
-      name: `stake`,
+      name: `submitDelegation`,
       args: [
         {
           amount: 50,

--- a/test/unit/specs/components/staking/ModalStake.spec.js
+++ b/test/unit/specs/components/staking/ModalStake.spec.js
@@ -1,16 +1,11 @@
 "use strict"
 
-import { createLocalVue, mount } from "@vue/test-utils"
+import { mount } from "@vue/test-utils"
 import ModalStake from "staking/ModalStake"
-import Vuelidate from "vuelidate"
 
 // Create an example stake modal window.
 const Wrapper = () => {
-  const localVue = createLocalVue()
-  localVue.use(Vuelidate)
-
   return mount(ModalStake, {
-    localVue,
     propsData: {
       fromOptions: [
         `My Wallet - cosmosaccaddr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`

--- a/test/unit/specs/components/staking/ModalStake.spec.js
+++ b/test/unit/specs/components/staking/ModalStake.spec.js
@@ -1,0 +1,63 @@
+"use strict"
+
+import { createLocalVue, mount } from "@vue/test-utils"
+import ModalStake from "staking/ModalStake"
+import Vuelidate from "vuelidate"
+
+// Create an example stake modal window.
+const Wrapper = () => {
+  const localVue = createLocalVue()
+  localVue.use(Vuelidate)
+
+  return mount(ModalStake, {
+    localVue,
+    propsData: {
+      fromOptions: [
+        `My Wallet - cosmosaccaddr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`
+      ],
+      maximum: 100,
+      to: `cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctplpn3au`
+    }
+  })
+}
+
+test(`the "amount" field defaults to 1`, () => {
+  expect(Wrapper().vm.amount).toEqual(1)
+})
+
+test(`display the 'To' address`, () => {
+  expect(Wrapper().find(`#to`).element.value).toEqual(
+    `cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctplpn3au`
+  )
+})
+
+test(`an error message is displayed if amount exceeds the maximum`, () => {
+  const wrapper = Wrapper()
+  wrapper.setData({ amount: 200 })
+
+  expect(wrapper.text().includes(`Amount must be between 1 and 100`)).toEqual(
+    true
+  )
+})
+
+test(`Stake button emits stake and close signals`, () => {
+  const wrapper = Wrapper()
+  wrapper.setData({ amount: 50 })
+  wrapper.vm.onStake()
+
+  expect(wrapper.emittedByOrder()).toEqual([
+    {
+      name: `stake`,
+      args: [
+        {
+          amount: 50,
+          from: `My Wallet - cosmosaccaddr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`
+        }
+      ]
+    },
+    {
+      name: `update:showModalStake`,
+      args: [false]
+    }
+  ])
+})

--- a/test/unit/specs/components/staking/PageValidator.spec.js
+++ b/test/unit/specs/components/staking/PageValidator.spec.js
@@ -1,5 +1,50 @@
 import setup from "../../../helpers/vuex-setup"
 import PageValidator from "renderer/components/staking/PageValidator"
+import { mount } from "@vue/test-utils"
+
+// Create a getters object from an object of simple values.
+const mockGetters = values =>
+  Object.assign(
+    ...Object.entries(values).map(([key, value]) => ({ [key]: () => value }))
+  )
+
+const getterValues = {
+  bondingDenom: `atom`,
+  config: { desktop: false },
+  delegates: {
+    delegates: [
+      {
+        owner: "1a2b3c",
+        pub_key: {
+          type: "AC26791624DE60",
+          data: "dlN5SLqeT3LT9WsUK5iuVq1eLQV2Q1JQAuyN0VwSWK0="
+        },
+        tokens: "19",
+        delegator_shares: "19",
+        description: {
+          description: "Herr Schmidt",
+          moniker: "herr_schmidt_revoked",
+          country: "DE"
+        },
+        revoked: true,
+        status: 2,
+        bond_height: "0",
+        bond_intra_tx_counter: 6,
+        proposer_reward_pool: null,
+        commission: "0",
+        commission_max: "0",
+        commission_change_rate: "0",
+        commission_change_today: "0",
+        prev_bonded_shares: "0"
+      }
+    ]
+  },
+  delegation: {
+    committedDelegates: { "1a2b3c": 0 },
+    unbondingDelegations: {}
+  },
+  keybase: `keybase`
+}
 
 describe("PageValidator", () => {
   let wrapper
@@ -10,37 +55,7 @@ describe("PageValidator", () => {
       doBefore: ({ router }) => {
         router.push("/staking/validators/1a2b3c")
       },
-      getters: {
-        config: () => ({ desktop: false }),
-        delegates: () => ({
-          delegates: [
-            {
-              owner: "1a2b3c",
-              pub_key: {
-                type: "AC26791624DE60",
-                data: "dlN5SLqeT3LT9WsUK5iuVq1eLQV2Q1JQAuyN0VwSWK0="
-              },
-              tokens: "19",
-              delegator_shares: "19",
-              description: {
-                description: "Herr Schmidt",
-                moniker: "herr_schmidt_revoked",
-                country: "DE"
-              },
-              revoked: true,
-              status: 2,
-              bond_height: "0",
-              bond_intra_tx_counter: 6,
-              proposer_reward_pool: null,
-              commission: "0",
-              commission_max: "0",
-              commission_change_rate: "0",
-              commission_change_today: "0",
-              prev_bonded_shares: "0"
-            }
-          ]
-        })
-      }
+      getters: mockGetters(getterValues)
     })
     wrapper = instance.wrapper
   })
@@ -121,5 +136,113 @@ describe("PageValidator", () => {
     wrapper = instance.wrapper
 
     expect(wrapper.vm.$el).toMatchSnapshot()
+  })
+})
+
+describe(`onStake`, () => {
+  // Create our own PageValidator here because the one above contains way too
+  // much magic.
+
+  it(`success`, async () => {
+    const $store = {
+      commit: jest.fn(),
+      dispatch: jest.fn(),
+      getters: getterValues
+    }
+
+    const {
+      vm: { onStake }
+    } = mount(PageValidator, {
+      mocks: {
+        $route: { params: { validator: `1a2b3c` } },
+        $store
+      }
+    })
+
+    await onStake({ amount: 10 })
+
+    expect($store.dispatch.mock.calls).toEqual([
+      [`submitDelegation`, [{ atoms: 10, delegate: { owner: `1a2b3c` } }]]
+    ])
+
+    expect($store.commit.mock.calls).toEqual([
+      [
+        `notify`,
+        {
+          body: `You have successfully staked your atoms.`,
+          title: `Successful Staking!`
+        }
+      ]
+    ])
+  })
+
+  it(`error`, async () => {
+    const $store = {
+      commit: jest.fn(),
+      dispatch: jest.fn(() => {
+        throw new Error(`message`)
+      }),
+      getters: getterValues
+    }
+
+    const {
+      vm: { onStake }
+    } = mount(PageValidator, {
+      mocks: {
+        $route: { params: { validator: `1a2b3c` } },
+        $store
+      }
+    })
+
+    await onStake({ amount: 10 })
+
+    expect($store.dispatch.mock.calls).toEqual([
+      [`submitDelegation`, [{ atoms: 10, delegate: { owner: `1a2b3c` } }]]
+    ])
+
+    expect($store.commit.mock.calls).toEqual([
+      [
+        `notifyError`,
+        {
+          body: `message`,
+          title: `Error While Staking atoms`
+        }
+      ]
+    ])
+  })
+
+  it(`error with data`, async () => {
+    const $store = {
+      commit: jest.fn(),
+      dispatch: jest.fn(() => {
+        throw new Error(`one\ntwo\nthree\nfour\nfive\nsix"seven`)
+      }),
+      getters: getterValues
+    }
+
+    const {
+      vm: { onStake }
+    } = mount(PageValidator, {
+      mocks: {
+        $route: { params: { validator: `1a2b3c` } },
+        $store
+      }
+    })
+
+    await onStake({ amount: 10 })
+
+    expect($store.dispatch.mock.calls).toEqual([
+      [`submitDelegation`, [{ atoms: 10, delegate: { owner: `1a2b3c` } }]]
+    ])
+
+    expect($store.commit.mock.calls).toEqual([
+      [
+        `notifyError`,
+        {
+          body: `Seven`,
+          title: `Error While Staking atoms`
+        }
+      ]
+    ])
   })
 })

--- a/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
@@ -524,8 +524,10 @@ exports[`PageValidator has the expected html structure 1`] = `
       </div>
     </section>
     <!---->
+    <!---->
     <button
       class="tm-btn"
+      id="Stake"
     >
       <span
         class="tm-btn__container tm-btn--primary"
@@ -1087,8 +1089,10 @@ exports[`PageValidator shows a default avatar 1`] = `
       </div>
     </section>
     <!---->
+    <!---->
     <button
       class="tm-btn"
+      id="Stake"
     >
       <span
         class="tm-btn__container tm-btn--primary"
@@ -1630,8 +1634,10 @@ exports[`PageValidator shows a default value if no moniker is set 1`] = `
       </div>
     </section>
     <!---->
+    <!---->
     <button
       class="tm-btn"
+      id="Stake"
     >
       <span
         class="tm-btn__container tm-btn--primary"

--- a/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
@@ -523,6 +523,22 @@ exports[`PageValidator has the expected html structure 1`] = `
         </main>
       </div>
     </section>
+    <!---->
+    <button
+      class="tm-btn"
+    >
+      <span
+        class="tm-btn__container tm-btn--primary"
+      >
+        <!---->
+        <!---->
+        <span
+          class="tm-btn__value"
+        >
+          Stake
+        </span>
+      </span>
+    </button>
     <div
       class="ps__rail-x"
       style="left: 0px; top: 0px;"
@@ -1070,6 +1086,22 @@ exports[`PageValidator shows a default avatar 1`] = `
         </main>
       </div>
     </section>
+    <!---->
+    <button
+      class="tm-btn"
+    >
+      <span
+        class="tm-btn__container tm-btn--primary"
+      >
+        <!---->
+        <!---->
+        <span
+          class="tm-btn__value"
+        >
+          Stake
+        </span>
+      </span>
+    </button>
   </main>
 </div>
 `;
@@ -1597,6 +1629,22 @@ exports[`PageValidator shows a default value if no moniker is set 1`] = `
         </main>
       </div>
     </section>
+    <!---->
+    <button
+      class="tm-btn"
+    >
+      <span
+        class="tm-btn__container tm-btn--primary"
+      >
+        <!---->
+        <!---->
+        <span
+          class="tm-btn__value"
+        >
+          Stake
+        </span>
+      </span>
+    </button>
   </main>
 </div>
 `;


### PR DESCRIPTION
Make progress against #1219.

Description:

Implements the new design for staking to a validator.  It does not remove the old one.

Still to be done:

## Jordan

- [ ] add `X` and `Cancel` buttons to design

## David & Fede

- [ ] write "Atoms" within `Amount` field
- [ ] allow selection of previously-staked validators in `From` field
- [ ] close window when clicking outside of it
- [ ] don't change layout when invalid amount error message is displayed

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
