### PR TITLE
Fabo/cache undelegations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Do not try to publish a release on every push to `develop`! @NodeGuy
 * validator url on txs leading to explorer @faboweb
+* cache undelegations @faboweb
 
 ## [0.10.2] - 2018-08-29
 

--- a/app/src/renderer/vuex/store.js
+++ b/app/src/renderer/vuex/store.js
@@ -26,6 +26,7 @@ export default (opts = {}) => {
       "setWalletBalances",
       "setWalletHistory",
       "setCommittedDelegation",
+      "setUnbondingDelegations",
       "setDelegates",
       "setKeybaseIdentities"
     ]
@@ -56,7 +57,8 @@ function persistState(state) {
         balances: state.wallet.balances
       },
       delegation: {
-        committedDelegates: state.delegation.committedDelegates
+        committedDelegates: state.delegation.committedDelegates,
+        unbondingDelegations: state.delegation.unbondingDelegations
       },
       delegates: {
         delegates: state.delegates.delegates

--- a/test/unit/specs/store/store.spec.js
+++ b/test/unit/specs/store/store.spec.js
@@ -85,12 +85,18 @@ describe("Store", () => {
       candidateId: lcdClientMock.validators[0],
       value: 1
     })
+    store.commit("setUnbondingDelegations", {
+      candidateId: lcdClientMock.validators[1],
+      value: 1
+    })
     jest.runAllTimers() // updating is waiting if more updates coming in, this skips the waiting
     await store.dispatch("signOut")
 
-    expect(store.state.delegates.delegates).toHaveLength(0)
     expect(
       store.state.delegation.committedDelegates[lcdClientMock.validators[0]]
+    ).toBeFalsy()
+    expect(
+      store.state.delegation.unbondingDelegations[lcdClientMock.validators[1]]
     ).toBeFalsy()
     expect(store.state.delegation.delegates).toHaveLength(0)
 
@@ -102,6 +108,9 @@ describe("Store", () => {
     expect(store.state.delegates.delegates).toHaveLength(3)
     expect(
       store.state.delegation.committedDelegates[lcdClientMock.validators[0]]
+    ).toBe(1)
+    expect(
+      store.state.delegation.unbondingDelegations[lcdClientMock.validators[1]]
     ).toBe(1)
     expect(store.state.delegation.delegates).toHaveLength(1)
   })


### PR DESCRIPTION
Description:

undelegations were not cache resulting in a view update of tokens even though nothing happened

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
