### PR TITLE
Fabo/1270 block user from staking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added staking transactions and fixed 100% height txs. Refactored modules/blockchain.js @okwme
 * test if build Voyager actually starts @faboweb
 * added new validator component @okwme
+* simple loading indicator for page staking @faboweb
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Do not try to publish a release on every push to `develop`! @NodeGuy
 * validator url on txs leading to explorer @faboweb
+* enable user to stake only after the request for his current delegations has returned @ƒaboweb
 
 ## [0.10.2] - 2018-08-29
 

--- a/app/src/renderer/components/staking/LiDelegate.vue
+++ b/app/src/renderer/components/staking/LiDelegate.vue
@@ -23,7 +23,7 @@
   .li-delegate__value.slashes
     // add .green .yellow or .red class to this span to trigger inidication by color
     span {{ slashes }}
-  template(v-if="userCanDelegate")
+  template(v-if="!disabled")
     .li-delegate__value.checkbox(v-if="committedDelegations[delegate.id]")
       i.material-icons lock
     .li-delegate__value.checkbox#remove-from-cart(v-else-if="inCart" @click='rm(delegate)')
@@ -41,7 +41,7 @@ import { maxBy } from "lodash"
 import { shortAddress } from "scripts/common"
 export default {
   name: "li-delegate",
-  props: ["delegate"],
+  props: ["delegate", "disabled"],
   computed: {
     ...mapGetters([
       "shoppingCart",
@@ -89,9 +89,6 @@ export default {
     },
     inCart() {
       return this.shoppingCart.find(c => c.id === this.delegate.id)
-    },
-    userCanDelegate() {
-      return this.shoppingCart.length > 0 || this.user.atoms > 0
     },
     delegateType() {
       return this.delegate.revoked

--- a/app/src/renderer/components/staking/PageStaking.vue
+++ b/app/src/renderer/components/staking/PageStaking.vue
@@ -67,6 +67,7 @@ export default {
   computed: {
     ...mapGetters([
       "delegates",
+      "delegation",
       "filters",
       "shoppingCart",
       "committedDelegations",
@@ -120,7 +121,10 @@ export default {
       }
     },
     userCanDelegate() {
-      return this.shoppingCart.length > 0 || this.user.atoms > 0
+      return (
+        (this.shoppingCart.length > 0 || this.user.atoms > 0) &&
+        this.delegation.loadedOnce
+      )
     },
     properties() {
       return [
@@ -211,11 +215,13 @@ export default {
 
   .tab
     cursor pointer
-    margin 0 .5em
+    margin 0 0.5em
     padding-bottom 0.5em
     margin-bottom 1em
+
     &:first-of-type
       cursor not-allowed
+
     &.tab-selected
       color var(--bright)
       border-bottom 2px solid var(--tertiary)

--- a/app/src/renderer/components/staking/PageStaking.vue
+++ b/app/src/renderer/components/staking/PageStaking.vue
@@ -18,14 +18,15 @@ tm-page(title='Staking')
     data-empty-search(v-else-if="!delegates.loading && sortedFilteredEnrichedDelegates.length === 0")
     template(v-else)
       panel-sort(:sort='sort', :properties="properties")
-      li-delegate(v-for='i in sortedFilteredEnrichedDelegates' :key='i.id' :delegate='i')
+      li-delegate(v-for='i in sortedFilteredEnrichedDelegates' :disabled="!userCanDelegate" :key='i.id' :delegate='i')
 
   .fixed-button-bar(v-if="!delegates.loading")
     template(v-if="userCanDelegate")
       .label #[strong {{ shoppingCart.length }}] validators selected
       tm-btn(id="go-to-bonding-btn" type="link" to="/staking/bond" :disabled="shoppingCart.length === 0" icon="chevron_right" icon-pos="right" value="Next" color="primary")
     template(v-else)
-      .label You do not have any {{bondingDenom}}s to stake.
+      .label(v-if="!delegation.loadedOnce && delegation.loading") Loading delegations...
+      .label(v-else) You do not have any {{bondingDenom}}s to stake.
       tm-btn(disabled icon="chevron_right" icon-pos="right" value="Next" color="primary")
 </template>
 

--- a/app/src/renderer/vuex/modules/delegation.js
+++ b/app/src/renderer/vuex/modules/delegation.js
@@ -1,6 +1,7 @@
 export default ({ node }) => {
   let emptyState = {
     loading: false,
+    loadedOnce: false,
 
     // our delegations, maybe not yet committed
     delegates: [],
@@ -92,6 +93,7 @@ export default ({ node }) => {
           }
         )
       }
+      state.loadedOnce = true
       state.loading = false
     },
     async updateDelegates({ dispatch }) {

--- a/app/src/renderer/vuex/store.js
+++ b/app/src/renderer/vuex/store.js
@@ -56,6 +56,7 @@ function persistState(state) {
         balances: state.wallet.balances
       },
       delegation: {
+        loadedOnce: state.delegation.loadedOnce,
         committedDelegates: state.delegation.committedDelegates
       },
       delegates: {


### PR DESCRIPTION
Description:

Blocks users from staking until the delegation infos have been loaded the first time. Also shows a little simple loading message:

![image](https://user-images.githubusercontent.com/5869273/45228048-5dafc500-b2c2-11e8-9292-dc3ccbdf1b26.png)

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!
