### PR TITLE
Use gaia-seeds.interblock.io as seed node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * reconnection errors did not show up correctly in view @faboweb
 * fixed crash when reconnecting @faboweb
 * fixed crash when using an offline fixed node @faboweb
+* yarn build:testnets now uses gaia-seeds.interblock.io as seed node @NodeGuy
 
 ## [0.10.2] - 2018-08-29
 

--- a/tasks/build/testnets/build.sh
+++ b/tasks/build/testnets/build.sh
@@ -9,10 +9,11 @@ echo ###########################################################################
 ## Create config.toml file.
 builds/Gaia/linux_amd64/gaiad init --name Voyager
 
-### Add seed nodes from
-### https://github.com/cosmos/cosmos-sdk/tree/5c8791743411cac58c502f3b18bfe8a1970e830e/cmd/gaia/testnets#add-seed-nodes
-sed --expression="s/seeds = \"\"/seeds = \"7c8b8fd03577cd4817f5be1f03d506f879df98d8@gaia-seed1.interblock.io:26656, a28737ff02391a6e00a1d3b79befd57e68e8264c@gaia-seed2.interblock.io:26656, 987ffd26640cd03d08ed7e53b24dfaa7956e612d@gaia-seed3.interblock.io:26656,837ab35ee80e6882da08ab6244ef27538e73aedd@gaia-seed4.interblock.io:26656\"/" \
-  --in-place ~/.gaiad/config/config.toml
+### Add seed node.
+sed \
+  --expression="s/seeds = \"\"/seeds = \"gaia-seeds.interblock.io\"/" \
+  --in-place \
+  ~/.gaiad/config/config.toml
 
 # Download the testnet configuration files
 rm --force --recursive builds/testnets

--- a/tasks/build/testnets/localBuild.sh
+++ b/tasks/build/testnets/localBuild.sh
@@ -4,14 +4,17 @@ if [ ! -f $(pwd)/../../../builds/Gaia/linux_amd64/gaiad ]; then
   printf "Gaia missing; building first.\n"
   (cd ../../.. && yarn build:gaia)
 fi
+
 docker create \
   --name=builder \
   --interactive \
   --rm	\
   golang:1.10.2
+
 docker cp "$(pwd)/../../../builds" builder:/go/builds
 docker cp build.sh builder:/go/builds/
 docker start builder
 docker exec builder /go/builds/build.sh
+rm -f -r ../../../builds/testnets
 docker cp builder:/go/builds/testnets "$(pwd)/../../../builds/testnets"
 docker stop builder


### PR DESCRIPTION
Description:

Previously we were using seed nodes from the documentation.  They proved unreliable so now we're trying gaia-seeds.interblock.io instead.