### PR TITLE
Refactor submitDelegation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added new validator profile page @faboweb
 * cleaning up new validator profile page and balance header @jbibla
 * Changed a bunch of JavaScript files to strict mode. @NodeGuy @faboweb
+* Refactord submitDelegation. @NodeGuy
 
 ### Fixed
 

--- a/app/src/renderer/components/staking/PageValidator.vue
+++ b/app/src/renderer/components/staking/PageValidator.vue
@@ -102,7 +102,7 @@ tm-page
 import { mapGetters } from "vuex"
 import { TmBtn, TmListItem, TmPage, TmPart, TmToolBar } from "@tendermint/ui"
 import { TmDataError } from "common/TmDataError"
-import { calculateTokens, shortAddress, ratToBigNumber } from "scripts/common"
+import { shortAddress, ratToBigNumber } from "scripts/common"
 import ModalStake from "staking/ModalStake"
 import numeral from "numeral"
 import AnchorCopy from "common/AnchorCopy"
@@ -210,22 +210,15 @@ export default {
       }
     },
     async submitDelegation({ amount }) {
-      const candidateId = this.validator.owner
-
-      const currentlyDelegated = calculateTokens(
-        this.validator,
-        this.delegation.committedDelegates[candidateId] || 0
-      )
-
-      const delegation = [
-        {
-          atoms: currentlyDelegated.plus(amount),
-          delegate: this.validator
-        }
-      ]
-
       try {
-        await this.$store.dispatch("submitDelegation", delegation)
+        await this.$store.dispatch("submitDelegation", {
+          delegations: [
+            {
+              atoms: amount,
+              delegate: this.validator
+            }
+          ]
+        })
 
         this.$store.commit("notify", {
           title: "Successful Staking!",

--- a/app/src/renderer/vuex/modules/delegation.js
+++ b/app/src/renderer/vuex/modules/delegation.js
@@ -136,49 +136,40 @@ export default ({ node }) => {
       return dispatch("getBondedDelegates", candidates)
     },
     async submitDelegation(
-      { rootState, state, dispatch, commit },
-      delegations
+      {
+        rootState: { config, user, wallet },
+        state,
+        dispatch,
+        commit
+      },
+      { delegations = [], unbondings = [] }
     ) {
-      let delegate = []
-      let unbond = []
-      for (let delegation of delegations) {
-        let candidateId = delegation.delegate.owner
-        let currentlyDelegated = 0
-        currentlyDelegated = calculateTokens(
-          delegation.delegate,
-          state.committedDelegates[candidateId] || 0
+      const denom = config.bondingDenom.toLowerCase()
+
+      const mappedDelegations = delegations.map(
+        ({ atoms, delegate: { owner } }) => ({
+          delegator_addr: wallet.address,
+          validator_addr: owner,
+          delegation: {
+            denom,
+            amount: String(atoms)
+          }
+        })
+      )
+
+      const mappedUnbondings = unbondings.map(({ atoms, delegate }) => ({
+        delegator_addr: wallet.address,
+        validator_addr: delegate.owner,
+        shares: String(
+          Math.abs(calculateShares(delegate, atoms)).toFixed(8) // TODO change to 10 when available https://github.com/cosmos/cosmos-sdk/issues/2317
         )
-        let amountChange =
-          parseFloat(delegation.atoms) - currentlyDelegated.toNumber()
-        let isBond = amountChange > 0
-        // skip if no change
-        if (amountChange === 0) continue
-        if (isBond) {
-          delegate.push({
-            delegator_addr: rootState.wallet.address,
-            validator_addr: candidateId,
-            delegation: {
-              denom: rootState.config.bondingDenom.toLowerCase(),
-              amount: String(amountChange)
-            }
-          })
-        } else {
-          unbond.push({
-            delegator_addr: rootState.wallet.address,
-            validator_addr: candidateId,
-            shares: String(
-              Math.abs(
-                calculateShares(delegation.delegate, amountChange)
-              ).toFixed(8) // TODO change to 10 when available https://github.com/cosmos/cosmos-sdk/issues/2317
-            )
-          })
-        }
-      }
+      }))
+
       await dispatch("sendTx", {
         type: "updateDelegations",
-        to: rootState.wallet.address, // TODO strange syntax
-        delegations: delegate,
-        begin_unbondings: unbond
+        to: wallet.address, // TODO strange syntax
+        delegations: mappedDelegations,
+        begin_unbondings: mappedUnbondings
       })
       // (optimistic update) we update the atoms of the user before we get the new values from chain
       let atomsDiff = delegations
@@ -191,7 +182,7 @@ export default ({ node }) => {
             ) - delegation.atoms
         )
         .reduce((sum, diff) => sum + diff, 0)
-      commit("setAtoms", rootState.user.atoms + atomsDiff)
+      commit("setAtoms", user.atoms + atomsDiff)
 
       // we optimistically update the committed delegations
       // TODO usually I would just query the new state through the LCD and update the state with the result, but at this point we still get the old shares

--- a/test/unit/specs/components/staking/PageValidator.spec.js
+++ b/test/unit/specs/components/staking/PageValidator.spec.js
@@ -1,4 +1,3 @@
-import BigNumber from "bignumber.js"
 import Delegation from "renderer/vuex/modules/delegation"
 import ModalStake from "staking/ModalStake"
 import setup from "../../../helpers/vuex-setup"
@@ -298,7 +297,7 @@ describe(`onStake`, () => {
         await submitDelegation({ amount: 10 })
 
         expect($store.dispatch.mock.calls).toEqual([
-          [`submitDelegation`, [{ atoms: BigNumber(10), delegate }]]
+          [`submitDelegation`, { delegations: [{ atoms: 10, delegate }] }]
         ])
 
         expect($store.commit.mock.calls).toEqual([
@@ -333,7 +332,7 @@ describe(`onStake`, () => {
         await submitDelegation({ amount: 10 })
 
         expect($store.dispatch.mock.calls).toEqual([
-          [`submitDelegation`, [{ atoms: BigNumber(10), delegate }]]
+          [`submitDelegation`, { delegations: [{ atoms: 10, delegate }] }]
         ])
 
         expect($store.commit.mock.calls).toEqual([
@@ -368,7 +367,7 @@ describe(`onStake`, () => {
         await submitDelegation({ amount: 10 })
 
         expect($store.dispatch.mock.calls).toEqual([
-          [`submitDelegation`, [{ atoms: BigNumber(10), delegate }]]
+          [`submitDelegation`, { delegations: [{ atoms: 10, delegate }] }]
         ])
 
         expect($store.commit.mock.calls).toEqual([
@@ -418,39 +417,41 @@ describe(`onStake`, () => {
         expect($store.dispatch.mock.calls).toEqual([
           [
             "submitDelegation",
-            [
-              {
-                atoms: BigNumber(10),
-                delegate: {
-                  bond_height: "0",
-                  bond_intra_tx_counter: 6,
-                  commission: "0.05",
-                  commission_change_rate: "0.01",
-                  commission_change_today: "0.005",
-                  commission_max: "0.1",
-                  delegator_shares: "19",
-                  description: {
-                    country: "DE",
-                    details: "Herr Schmidt",
-                    moniker: "herr_schmidt_revoked",
-                    website: "www.schmidt.de"
-                  },
-                  keybase: undefined,
-                  owner: "1a2b3c",
-                  prev_bonded_shares: "0",
-                  proposer_reward_pool: null,
-                  pub_key: {
-                    data: "dlN5SLqeT3LT9WsUK5iuVq1eLQV2Q1JQAuyN0VwSWK0=",
-                    type: "AC26791624DE60"
-                  },
-                  revoked: false,
-                  selfBond: 0.01,
-                  status: 2,
-                  tokens: "19",
-                  voting_power: "10"
+            {
+              delegations: [
+                {
+                  atoms: 10,
+                  delegate: {
+                    bond_height: "0",
+                    bond_intra_tx_counter: 6,
+                    commission: "0.05",
+                    commission_change_rate: "0.01",
+                    commission_change_today: "0.005",
+                    commission_max: "0.1",
+                    delegator_shares: "19",
+                    description: {
+                      country: "DE",
+                      details: "Herr Schmidt",
+                      moniker: "herr_schmidt_revoked",
+                      website: "www.schmidt.de"
+                    },
+                    keybase: undefined,
+                    owner: "1a2b3c",
+                    prev_bonded_shares: "0",
+                    proposer_reward_pool: null,
+                    pub_key: {
+                      data: "dlN5SLqeT3LT9WsUK5iuVq1eLQV2Q1JQAuyN0VwSWK0=",
+                      type: "AC26791624DE60"
+                    },
+                    revoked: false,
+                    selfBond: 0.01,
+                    status: 2,
+                    tokens: "19",
+                    voting_power: "10"
+                  }
                 }
-              }
-            ]
+              ]
+            }
           ],
           [
             "sendTx",

--- a/test/unit/specs/store/delegation.spec.js
+++ b/test/unit/specs/store/delegation.spec.js
@@ -72,13 +72,20 @@ describe("Module: Delegations", () => {
 
     jest.spyOn(store._actions.sendTx, "0")
 
-    let bondings = [123, 456, 0]
-    const delegations = store.state.delegates.delegates.map((delegate, i) => ({
-      delegate,
-      atoms: bondings[i]
-    }))
+    const delegates = store.state.delegates.delegates
 
-    await store.dispatch("submitDelegation", delegations)
+    const delegations = [
+      {
+        delegate: delegates[0],
+        atoms: 109
+      },
+      {
+        delegate: delegates[1],
+        atoms: 456
+      }
+    ]
+
+    await store.dispatch("submitDelegation", { delegations })
 
     expect(store._actions.sendTx[0].mock.calls).toMatchSnapshot()
   })
@@ -91,12 +98,20 @@ describe("Module: Delegations", () => {
     await store.dispatch("getBondedDelegates")
 
     jest.spyOn(store._actions.sendTx, "0")
-    let bondings = [10, 100, 0]
-    const delegations = store.state.delegates.delegates.map((delegate, i) => ({
-      delegate,
-      atoms: bondings[i]
-    }))
-    await store.dispatch("submitDelegation", delegations)
+    const delegates = store.state.delegates.delegates
+
+    const unbondings = [
+      {
+        delegate: delegates[0],
+        atoms: -113
+      },
+      {
+        delegate: delegates[1],
+        atoms: -356
+      }
+    ]
+
+    await store.dispatch("submitDelegation", { unbondings })
     expect(store._actions.sendTx[0].mock.calls).toMatchSnapshot()
   })
 
@@ -178,18 +193,20 @@ describe("Module: Delegations", () => {
 
   it("should undelegate", async () => {
     // store the unbondingDelegation in the lcdclientmock
-    await store.dispatch("submitDelegation", [
-      {
-        delegate: {
-          owner: lcdClientMock.validators[0],
-          delegator_shares: "100",
-          tokens: "100"
-        },
-        balance: {
-          amount: "100"
+    await store.dispatch("submitDelegation", {
+      unbondings: [
+        {
+          delegate: {
+            owner: lcdClientMock.validators[0],
+            delegator_shares: "100",
+            tokens: "100"
+          },
+          balance: {
+            amount: "100"
+          }
         }
-      }
-    ])
+      ]
+    })
     store.commit("setUnbondingDelegations", {
       validator_addr: lcdClientMock.validators[0],
       balance: { amount: "100" }


### PR DESCRIPTION
Closes #1300

Description:

Now that we've gotten rid of PageBond we can simplify `submitDelegation` so that it doesn't care about previous delegations.