### PR TITLE
Add `watch` script for unit tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * more tests for new staking modal @NodeGuy
 * Add commission and uptime to LiValidator @fedekunze
 * Delete old bonding page @fedekunze
+* `watch` script for running unit tests @faboweb @NodeGuy
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ Voyager is using [Jest](https://facebook.github.io/jest) to run unit tests.
 $ yarn test
 ```
 
+You can run the unit tests for a single file (e.g.,
+PageValidator.spec.js) whenever there are changes like this:
+
+```shell
+$ yarn watch PageValidator
+```
+
 To check test coverage locally run following. It will spin up a webserver and provide you with a link to the coverage report web page.
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "release": "node ./tasks/releasePullRequest.js",
     "precommit": "pretty-quick --staged",
     "prepush": "bash ./tasks/changelog-changed-check.sh && yarn lint && yarn test:unit",
-    "postcheckout": "yarn"
+    "postcheckout": "yarn",
+    "watch": "tasks/watch.sh"
   },
   "devDependencies": {
     "@nodeguy/cli": "0.2.2",

--- a/tasks/watch.sh
+++ b/tasks/watch.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+jest $1 --watch --collectCoverageFrom='["**/*'$1'*"]' --coverage


### PR DESCRIPTION
Adds @faboweb's cool unit test watch shortcut as an NPM script:

> I created a shortcut to test single components with jest and get the correct coverage for that file. Add following snippet to your `~/.bash_profile`:
```
jestw() {
    jest $1 --watch --collectCoverageFrom='["**/*'$1'*"]' --coverage
}
```

> Load your bash profile `source ~/.bash_profile`.
> Now you can use `jestw PageValidator` and get the correct coverage for that file. (edited)

With this PR you can do `yarn watch PageValidator` instead.