### PR TITLE
Jordan/1473 power not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Updated contribution guidelines. @faboweb
 * [\#1447](https://github.com/cosmos/voyager/issues/1447) Removed titles from all pages. @faboweb
 * Updated PR template @fedekunze
+* [\#1473](https://github.com/cosmos/voyager/issues/1473) added "percent of vote" to validator in vuex module instead of in component @jbibla
 
 ### Fixed
 

--- a/app/src/renderer/vuex/modules/delegates.js
+++ b/app/src/renderer/vuex/modules/delegates.js
@@ -2,6 +2,7 @@
 
 import BN from "bignumber.js"
 import { ratToBigNumber } from "scripts/common"
+import num from "scripts/num"
 import { isEmpty } from "lodash"
 export default ({ node }) => {
   const emptyState = {
@@ -16,18 +17,21 @@ export default ({ node }) => {
       state.loading = loading
     },
     setDelegates(state, validators) {
-      validators.forEach(validator => {
-        validator.id = validator.operator_address
-        validator.voting_power = ratToBigNumber(validator.tokens)
-      })
-      state.delegates = validators
-
       // update global power for quick access
-      state.globalPower = state.delegates
+      state.globalPower = validators
         .reduce((sum, validator) => {
           return sum.plus(ratToBigNumber(validator.tokens))
         }, new BN(0))
         .toNumber()
+
+      validators.forEach(validator => {
+        validator.id = validator.operator_address
+        validator.voting_power = ratToBigNumber(validator.tokens)
+        validator.percent_of_vote = num.percent(
+          validator.voting_power / state.globalPower
+        )
+      })
+      state.delegates = validators
     },
     setSelfBond(
       state,

--- a/test/unit/specs/components/staking/PageValidator.spec.js
+++ b/test/unit/specs/components/staking/PageValidator.spec.js
@@ -652,6 +652,7 @@ describe(`onDelegation`, () => {
                         id: lcdClientMock.validators[0],
                         keybase: undefined,
                         operator_address: lcdClientMock.validators[0],
+                        percent_of_vote: `65.52%`,
                         prev_bonded_shares: `0`,
                         proposer_reward_pool: null,
                         pub_key: `cosmoschiapudding123456789`,

--- a/test/unit/specs/store/delegates.spec.js
+++ b/test/unit/specs/store/delegates.spec.js
@@ -16,6 +16,7 @@ describe(`Module: Delegates`, () => {
     mutations.setDelegates(state, [
       {
         operator_address: `foo`,
+        percent_of_vote: `100.00%`,
         tokens: `10`
       }
     ])
@@ -23,6 +24,7 @@ describe(`Module: Delegates`, () => {
       {
         id: `foo`,
         operator_address: `foo`,
+        percent_of_vote: `100.00%`,
         tokens: `10`,
         voting_power: BN(10)
       }
@@ -42,6 +44,7 @@ describe(`Module: Delegates`, () => {
       {
         id: `foo`,
         operator_address: `foo`,
+        percent_of_vote: `100.00%`,
         tokens: `12`,
         updated: true,
         voting_power: BN(12)
@@ -62,6 +65,7 @@ describe(`Module: Delegates`, () => {
       {
         id: `foo`,
         operator_address: `foo`,
+        percent_of_vote: `100.00%`,
         tokens: `4000/40`,
         updated: true,
         voting_power: BN(100)


### PR DESCRIPTION
Closes #1473 

_Description:_

percent of vote was being calculated on one component instead of closer to the source of the validator object. now, we'll add it to the validator object in the vuex module and it will always be there when we need it 😄 

❤️ Thank you!

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

* [x] Added entries in `CHANGELOG.md` with issue # and GitHub username
* [x] Reviewed `Files changed` in the github PR explorer
