### PR TITLE
fedekunze/1440 check if websocket exists before disconnecting RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [\#1409](https://github.com/cosmos/voyager/issues/1409) Fixed disabled unbond and redelegation button when delegation amount was less than 1 @fedekunze
 * [\#1517](https://github.com/cosmos/voyager/issues/1517) Fixed wrong account format used for querying selfBond @faboweb
 * [\#1503](https://github.com/cosmos/voyager/issues/1503) Added e2e test for balance updates after delegation @faboweb
+* [\#1440](https://github.com/cosmos/voyager/issues/1440) Fixed an error that prevented disconnecting from the RPC websocket if it wasn't defined
 
 ## [0.10.7] - 2018-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [\#1409](https://github.com/cosmos/voyager/issues/1409) Fixed disabled unbond and redelegation button when delegation amount was less than 1 @fedekunze
 * [\#1517](https://github.com/cosmos/voyager/issues/1517) Fixed wrong account format used for querying selfBond @faboweb
 * [\#1503](https://github.com/cosmos/voyager/issues/1503) Added e2e test for balance updates after delegation @faboweb
-* [\#1440](https://github.com/cosmos/voyager/issues/1440) Fixed an error that prevented disconnecting from the RPC websocket if it wasn't defined
+* [\#1440](https://github.com/cosmos/voyager/issues/1440) Fixed an error that prevented disconnecting from the RPC websocket if it wasn't defined @fedekunze
 
 ## [0.10.7] - 2018-10-10
 

--- a/app/src/renderer/connectors/rpcWrapper.js
+++ b/app/src/renderer/connectors/rpcWrapper.js
@@ -11,7 +11,7 @@ module.exports = function setRpcWrapper(container) {
       connected: true
     },
     rpcDisconnect() {
-      if (!container.rpc) return
+      if (!container.rpc || !container.rpc.ws) return
 
       console.log(`removing old websocket`)
 


### PR DESCRIPTION
Closes #1440 

_Description:_

<!-- Briefly describe what you're adding or fixing with this PR -->

The only `.destroy()` that we have in our codebase is the one that's used to disconnect the RPC

❤️ Thank you!

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

* [x] Added entries in `CHANGELOG.md` with issue # and GitHub username
* [x] Reviewed `Files changed` in the github PR explorer
