### PR TITLE
Spike separate window for account creation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-app/dist
 builds/*
 coverage
 node_modules

--- a/app/dist/createAccount.html
+++ b/app/dist/createAccount.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Create Account</title>
+  <style type="text/css">
+
+  </style>
+</head>
+
+<body>
+  <main class="tm-form-main">
+    <div class="tm-session-header"><a><i class="material-icons">arrow_back</i></a>
+      <div class="tm-session-title">Create Account</div><a><i class="material-icons">help_outline</i></a>
+    </div>
+    <div class="tm-session-main ps">
+      <div class="tm-form-group"><label for="sign-up-name" class="tm-form-group__label">Account Name</label>
+        <div class="tm-form-group__field"><input type="text" placeholder="Must be at least 5 characters" class="tm-field"
+            id="sign-up-name">
+          <div class="tm-form-msg sm tm-form-msg--error">Name is required</div>
+        </div>
+      </div>
+      <div class="tm-form-group"><label for="sign-up-password" class="tm-form-group__label">Password</label>
+        <div class="tm-form-group__field"><input type="password" placeholder="Must be at least 10 characters" class="tm-field"
+            id="sign-up-password">
+          <div class="tm-form-msg sm tm-form-msg--error">Password is required</div>
+          <!---->
+        </div>
+      </div>
+      <div class="tm-form-group">
+        <!----><label for="sign-up-password-confirm" class="tm-form-group__label">Confirm Password</label>
+        <div class="tm-form-group__field"><input type="password" placeholder="Enter password again" class="tm-field" id="sign-up-password-confirm">
+          <!---->
+        </div>
+      </div>
+      <div class="tm-form-group">
+        <!----><label for="sign-up-seed" class="tm-form-group__label">Seed Phrase</label>
+        <div class="tm-form-group__field"><textarea class="tm-field-seed tm-field" id="sign-up-seed" disabled="disabled"
+            style="overflow: hidden; word-wrap: break-word; resize: none; height: 80px;"></textarea>
+          <div class="sm tm-form-msg sm tm-form-msg--desc">Please back up the seed phrase for this account. This seed
+            phrase cannot be recovered.</div>
+        </div>
+      </div>
+      <div class="tm-form-group">
+        <!---->
+        <!---->
+        <div class="tm-form-group__field">
+          <div class="tm-field-checkbox">
+            <div class="tm-field-checkbox-input"><input id="sign-up-warning" type="checkbox"></div><label for="sign-up-warning"
+              class="tm-field-checkbox-label">I have securely written down my seed. I understand that lost seeds cannot
+              be recovered.</label>
+          </div>
+          <div class="tm-form-msg sm tm-form-msg--error">Recovery confirmation is required</div>
+        </div>
+      </div>
+      <div class="tm-form-group">
+        <!---->
+        <!---->
+        <div class="tm-form-group__field">
+          <div class="tm-field-checkbox">
+            <div class="tm-field-checkbox-input"><input id="error-collection" type="checkbox"></div><label for="error-collection"
+              class="tm-field-checkbox-label">I'd like to opt in for remote error tracking to help improve Voyager.</label>
+          </div>
+        </div>
+      </div>
+      <div class="ps__rail-x" style="left: 0px; bottom: 0px;">
+        <div class="ps__thumb-x" tabindex="0" style="left: 0px; width: 0px;"></div>
+      </div>
+      <div class="ps__rail-y" style="top: 0px; right: 0px;">
+        <div class="ps__thumb-y" tabindex="0" style="top: 0px; height: 0px;"></div>
+      </div>
+    </div>
+    <div class="tm-session-footer"><button onclick="onNext()" class="tm-btn"><span class="tm-btn__container tm-btn__icon-right tm-btn--size-lg">
+          <span class="tm-btn__value">Next</span></span></button></div>
+  </main>
+  <script>
+    const { ipcRenderer } = require(`electron`)
+
+    ;(async () => {
+      const phrase = await (await fetch(`http://localhost:9070/keys/seed`)).text()
+      document.getElementById(`sign-up-seed`).value = phrase
+    })()
+
+    const onNext = () => {
+      const name = document.getElementById(`sign-up-name`).value
+      ipcRenderer.send(`createAccount`, name)
+    }
+  </script>
+</body>
+
+</html>

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -20,6 +20,7 @@ global.config = config // to make the config accessable from renderer
 require(`electron-debug`)()
 
 let shuttingDown = false
+let createAccountWindow
 let mainWindow
 let lcdProcess
 let streams = []
@@ -122,6 +123,19 @@ async function shutdown() {
   })
 }
 
+const showCreateAccountWindow = parent => {
+  createAccountWindow = new BrowserWindow({
+    center: true,
+    modal: true,
+    parent,
+    webPreferences: {
+      devTools: false
+    }
+  })
+
+  createAccountWindow.loadURL(`${winURL}/createAccount.html`)
+}
+
 function createWindow() {
   mainWindow = new BrowserWindow({
     show: false,
@@ -139,6 +153,8 @@ function createWindow() {
   mainWindow.once(`ready-to-show`, () => {
     setTimeout(() => {
       mainWindow.show()
+      showCreateAccountWindow(mainWindow)
+
       if (DEV || JSON.parse(process.env.COSMOS_DEVTOOLS || `false`)) {
         mainWindow.webContents.openDevTools()
         // we need to reload at this point to make sure sourcemaps are loaded correctly
@@ -428,6 +444,11 @@ const eventHandlers = {
 
   "successful-launch": () => {
     console.log(`[START SUCCESS] Vue app successfuly started`)
+  },
+
+  createAccount: (event, name) => {
+    createAccountWindow.close()
+    console.log(`Received name for creating account: ${name}`)
   }
 }
 


### PR DESCRIPTION
Closes #1519

_Description:_

This PR is not intended to be merged and it doesn't matter if the tests pass or not.

Things to note:

* A separate BrowserWindow is created just for displaying the `Create Account` form (with the seed words).
* The seed words are requested from Gaia Lite via HTTP and displayed.
* No modules are imported.
* Vue is not used.
* Custom HTML is used with a section for CSS (but I didn't bother to fill it in).
* It will look fairly seamless for the user—just like the current `Create Account` page.
* Type in a name under `Account Name` and hit `Next`.  The window will close and the name will be sent via IPC back to the main process.  You can see it displayed in the terminal.

Conclusion:  All of the mechanisms required to make this work have been demonstrated.
---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

* [ ] Added entries in `CHANGELOG.md` with issue # and GitHub username
* [ ] Reviewed `Files changed` in the github PR explorer
