### PR TITLE
automatic release created for v0.666.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.666.2] - 2018-11-13
+
 ### Added
 
 * Contract tests for `keys` endpoints in lcdClient. @NodeGuy

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cosmos-voyager",
   "productName": "Cosmos Voyager",
-  "version": "0.666.1",
+  "version": "0.666.2",
   "description": "Voyager is an electron-based user interface for the Cosmos Network.",
   "author": "All In Bits, Inc <hello@tendermint.com>",
   "license": "Apache-2.0",

--- a/tasks/publish.js
+++ b/tasks/publish.js
@@ -23,7 +23,7 @@ ${recentChanges(changeLog)}`
 const publishRelease = ({ notes, tag, token }) =>
   util.promisify(release)({
     token,
-    operator_address: `cosmos`,
+    owner: `cosmos`,
     repo: `voyager`,
     tag,
     name: `Cosmos Voyager Alpha ${tag} (UNSAFE)`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5212,7 +5212,7 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
 
 mkdirp@~0.3.5:
   version "0.3.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
+  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
 
 mkpath@^0.1.0:
   version "0.1.0"
@@ -5254,7 +5254,7 @@ ms@2.0.0:
 
 multer@^0.1.8:
   version "0.1.8"
-  resolved "https://registry.yarnpkg.com/multer/-/multer-0.1.8.tgz#551b8a6015093701bcacc964916b1ae06578f37b"
+  resolved "http://registry.npmjs.org/multer/-/multer-0.1.8.tgz#551b8a6015093701bcacc964916b1ae06578f37b"
   dependencies:
     busboy "~0.2.9"
     mkdirp "~0.3.5"
@@ -5643,7 +5643,7 @@ onetime@^2.0.0:
 
 ono@^1.0.22:
   version "1.0.22"
-  resolved "https://registry.yarnpkg.com/ono/-/ono-1.0.22.tgz#5f4ecbea7e3d3e972c0a03a3fd7f361368604a68"
+  resolved "http://registry.npmjs.org/ono/-/ono-1.0.22.tgz#5f4ecbea7e3d3e972c0a03a3fd7f361368604a68"
 
 ono@^4.0.5, ono@^4.0.6:
   version "4.0.10"
@@ -7577,7 +7577,7 @@ swagger-methods@^1.0.0, swagger-methods@^1.0.4:
 
 swagger-parser@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/swagger-parser/-/swagger-parser-4.1.0.tgz#5fb08ccc0c5abb8f9de7cba6c5e437736d8a10f5"
+  resolved "http://registry.npmjs.org/swagger-parser/-/swagger-parser-4.1.0.tgz#5fb08ccc0c5abb8f9de7cba6c5e437736d8a10f5"
   dependencies:
     call-me-maybe "^1.0.1"
     debug "^3.1.0"


### PR DESCRIPTION
# ONLY A TEST

### Added

* Contract tests for `keys` endpoints in lcdClient. @NodeGuy
* Protected Gaia Lite process with a mutex to prevent locking error. @NodeGuy
* catching errors on cache encryption. @faboweb
* [\#1436](https://github.com/cosmos/voyager/issues/1436) governance endpoints and vuex module @fedekunze
* [\#1482](https://github.com/cosmos/voyager/issues/1482) Added ESLint errors: no-var. @sgobotta
* [\#1449](https://github.com/cosmos/voyager/issues/1449) shortNumber to num scripts for more readable numbers. @jbibla
* [\#1464](https://github.com/cosmos/voyager/issues/1464) Added governance transactions to tx history page @fedekunze
* [\1401](https://github.com/cosmos/voyager/issues/1401) Display governance proposals index. @fedekunze
* [\#1472](https://github.com/cosmos/voyager/issues/1472) Added mock functionality for redelegation @fedekunze + @faboweb
* [\#1501](https://github.com/cosmos/voyager/issues/1501) Vote on proposals through modal @fedekunze + @jbibla
* [\1502](https://github.com/cosmos/voyager/issues/1502) A page for each proposal. @jbibla

### Changed

* Changed minor component of version number to match testnet version. @NodeGuy
* [\#1433](https://github.com/cosmos/voyager/issues/1433) Migrated to latest SDK commit 6c9e71b654995b22e3ba4d121553ab20432616a9. @faboweb
* [\#1183](https://github.com/cosmos/voyager/issues/1183) Changed a bunch of JavaScript files to strict mode. @NodeGuy
* Updated contribution guidelines. @faboweb
* [\#1447](https://github.com/cosmos/voyager/issues/1447) Removed titles from all pages. @faboweb
* Updated PR template @fedekunze
* [\#1454](https://github.com/cosmos/voyager/issues/1454) Updated a bunch of words to (hopefully) be clearer. @jbibla
* [\#1473](https://github.com/cosmos/voyager/issues/1473) added "percent of vote" to validator in vuex module instead of in component @jbibla
* [\#1497](https://github.com/cosmos/voyager/issues/1451) Using an html table for table validators component @jbibla
* [\#1496](https://github.com/cosmos/voyager/issues/1496) display validator pub_key instead of operator_address on livalidator and validator profile @jbibla
* made running a local node easier by reducing it to 2 commands and presetting an account. @faboweb
* [\#1504](https://github.com/cosmos/voyager/issues/1504) updates @tendermint/UI library to 0.4.1 @faboweb
* [\#1504](https://github.com/cosmos/voyager/issues/1504) updates @tendermint/UI library @faboweb
* [\#1410](https://github.com/cosmos/voyager/issues/1410) removed end undelegations as not needed in the SDK anymore

### Fixed

* Fixed gaia binary not be found on linux and windows in development @faboweb
* [\#1419](https://github.com/cosmos/voyager/issues/1419) Restored "Amount" label to delegation modal. @NodeGuy
* Fixed upstream cross compilation issue from SDK @faboweb
* [\#1446](https://github.com/cosmos/voyager/issues/1446) and [\#1445](https://github.com/cosmos/voyager/issues/1445) Fixed sorting in validator tables. @NodeGuy
* [\#1487](https://github.com/cosmos/voyager/issues/1487) Fixed running of local testnet. @NodeGuy
* [\#1480](https://github.com/cosmos/voyager/issues/1480) Fixed "duplicate CONN" errors in E2E tests. @NodeGuy
* [\#1480](https://github.com/cosmos/voyager/issues/1480) Fixed false detection of node crash in e2e test start. @faboweb
* [\#1451](https://github.com/cosmos/voyager/issues/1451) Provide better sourcemaps to make debugging easier. @faboweb
* [\#1409](https://github.com/cosmos/voyager/issues/1409) Fixed disabled unbond and redelegation button when delegation amount was less than 1 @fedekunze
* [\#1500](https://github.com/cosmos/voyager/issues/1500) Fixed wrong optimistic updates to the atom balance after staking @faboweb @fedekunze
* [\#1517](https://github.com/cosmos/voyager/issues/1517) Fixed wrong account format used for querying selfBond @faboweb
* [\#1503](https://github.com/cosmos/voyager/issues/1503) Added e2e test for balance updates after delegation @faboweb
* [\#1131](https://github.com/cosmos/voyager/issues/1131) Display only error message on notifications @fedekunze
* [\#1440](https://github.com/cosmos/voyager/issues/1440) Fixed an error that prevented disconnecting from the RPC websocket if it wasn't defined @fedekunze
