### PR TITLE
Jordan/1321 improved modal stylez

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [\#1575](https://github.com/cosmos/voyager/issues/1575) Fixed tags on governace transactions query @fedekunze
 - [\#1590](https://github.com/cosmos/voyager/issues/1590) Fixed empty error notifications caused by latest SDK update @fedekunze
 - [\#1596](https://github.com/cosmos/voyager/issues/1596) Fixed error that prevented from triggering updates after submitting a new proposal @fedekunze
+- [\#1321](https://github.com/cosmos/voyager/issues/1321) Fixed styling on TmModal @jbibla
 
 ## [0.10.7] - 2018-10-10
 

--- a/app/src/renderer/components/common/TmModal.vue
+++ b/app/src/renderer/components/common/TmModal.vue
@@ -7,11 +7,11 @@ div(:class='cssClass' @click.self="close()")
       .tm-modal-title
         slot(name='title')
       .tm-modal-icon.tm-modal-close(@click="close()")
-        i.material-icons close
+        i.material-icons(v-if="close") close
     main.tm-modal-main
       slot
-    footer.tm-modal-footer
-      slot(name='footer')
+      footer.tm-modal-footer
+        slot(name='footer')
 </template>
 
 <script>
@@ -60,50 +60,35 @@ export default {
   box-shadow hsla(0,0,0,0.25) 0 0.25rem 1rem
   display flex
   flex-flow column nowrap
-  min-width 20rem
-  max-width 40rem
+  width 30rem
 
 .tm-modal-header
   display flex
   flex-flow row nowrap
   align-items center
-  flex 0 0 3rem + 0.0625rem
-  padding 2rem 1rem
+  padding 1rem 1.5rem
   background var(--app-nav)
 
 .tm-modal-icon
-  height 3rem
   display flex
   align-items center
   justify-content center
-
   i
     font-size lg
+
   &.tm-modal-close
     cursor pointer
-    i
-      color var(--txt)
     &:hover i
       color var(--link)
-
-.tm-modal-icon + .tm-modal-title
-  padding-left 0
 
 .tm-modal-title
   flex 1
   font-size h3
   font-weight 500
   color var(--bright)
-  padding 0 1rem
 
 .tm-modal-main
-  padding 2rem 1rem
-
-.tm-modal-main + .tm-modal-footer
-  border-top px solid var(--bc)
-
-.tm-modal-main
-  flex 1
+  padding 1rem 1.5rem
   display flex
   flex-flow column
   justify-content center
@@ -111,22 +96,12 @@ export default {
   .ps-scrollbar-y-rail
     display none
 
-.tm-modal-main p
-  margin-bottom 1rem
-  padding 0 1rem
-  word-wrap break-word
-  color var(--txt)
+  p
+    margin-bottom 1rem
+    word-wrap break-word
 
 .tm-modal-footer
-  padding 1rem
-
-  button
-    padding-left 1rem
-
-  &:empty
-    display none
-
-.tm-modal-footer > div
+  padding-top 2rem
   display flex
   justify-content flex-end
 </style>

--- a/app/src/renderer/components/staking/PageValidator.vue
+++ b/app/src/renderer/components/staking/PageValidator.vue
@@ -101,8 +101,8 @@ tm-page(data-title="Validator")
       :maximum="myBond"
       :to="this.wallet.address"
     )
-    tm-modal(:close="closeCannotModal" icon="warning" v-if="showCannotModal")
-      div(slot='title') Cannot Complete {{ action == `delegate`? `Delegation` : `Undelegation` }}
+    tm-modal(:close="closeCannotModal" v-if="showCannotModal")
+      div(slot='title') Cannot {{ action == `delegate`? `Delegate` : `Undelegate` }}
       p You have no {{ bondingDenom }}s {{ action == `undelegate` ? `delegated `: `` }}to {{ action == `delegate` ? `delegate.` : `this validator.` }}
       div(slot='footer')
         tmBtn(

--- a/test/unit/specs/components/common/__snapshots__/TmModal.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmModal.spec.js.snap
@@ -26,10 +26,11 @@ exports[`TmModal has the expected html structure 1`] = `
     </header>
     <main
       class="tm-modal-main"
-    />
-    <footer
-      class="tm-modal-footer"
-    />
+    >
+      <footer
+        class="tm-modal-footer"
+      />
+    </main>
   </div>
 </div>
 `;

--- a/test/unit/specs/components/common/__snapshots__/TmModalHelp.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmModalHelp.spec.js.snap
@@ -49,10 +49,10 @@ exports[`TmModalHelp has the expected html structure 1`] = `
       <p>
         Thanks for improving Cosmos Voyager!
       </p>
+      <footer
+        class="tm-modal-footer"
+      />
     </main>
-    <footer
-      class="tm-modal-footer"
-    />
   </div>
 </div>
 `;

--- a/test/unit/specs/components/wallet/__snapshots__/PageSend.spec.js.snap
+++ b/test/unit/specs/components/wallet/__snapshots__/PageSend.spec.js.snap
@@ -2389,47 +2389,47 @@ exports[`PageSend should trigger confirmation modal if form is corect 1`] = `
           >
             This transaction cannot be undone.
           </p>
+          <footer
+            class="tm-modal-footer"
+          >
+            <div>
+              <button
+                class="tm-btn"
+                id="send-cancel-btn"
+                type="button"
+              >
+                <span
+                  class="tm-btn__container"
+                >
+                  <!---->
+                  <!---->
+                  <span
+                    class="tm-btn__value"
+                  >
+                    Cancel
+                  </span>
+                </span>
+              </button>
+              <button
+                class="tm-btn"
+                id="send-confirmation-btn"
+                type="button"
+              >
+                <span
+                  class="tm-btn__container tm-btn--primary"
+                >
+                  <!---->
+                  <!---->
+                  <span
+                    class="tm-btn__value"
+                  >
+                    Confirm
+                  </span>
+                </span>
+              </button>
+            </div>
+          </footer>
         </main>
-        <footer
-          class="tm-modal-footer"
-        >
-          <div>
-            <button
-              class="tm-btn"
-              id="send-cancel-btn"
-              type="button"
-            >
-              <span
-                class="tm-btn__container"
-              >
-                <!---->
-                <!---->
-                <span
-                  class="tm-btn__value"
-                >
-                  Cancel
-                </span>
-              </span>
-            </button>
-            <button
-              class="tm-btn"
-              id="send-confirmation-btn"
-              type="button"
-            >
-              <span
-                class="tm-btn__container tm-btn--primary"
-              >
-                <!---->
-                <!---->
-                <span
-                  class="tm-btn__value"
-                >
-                  Confirm
-                </span>
-              </span>
-            </button>
-          </div>
-        </footer>
       </div>
     </div>
   </main>

--- a/test/unit/specs/components/wallet/__snapshots__/TmModalSendConfirmation.spec.js.snap
+++ b/test/unit/specs/components/wallet/__snapshots__/TmModalSendConfirmation.spec.js.snap
@@ -47,47 +47,47 @@ exports[`TmModalSendConfirmation has the expected html structure 1`] = `
       >
         This transaction cannot be undone.
       </p>
+      <footer
+        class="tm-modal-footer"
+      >
+        <div>
+          <button
+            class="tm-btn"
+            id="send-cancel-btn"
+            type="button"
+          >
+            <span
+              class="tm-btn__container"
+            >
+              <!---->
+              <!---->
+              <span
+                class="tm-btn__value"
+              >
+                Cancel
+              </span>
+            </span>
+          </button>
+          <button
+            class="tm-btn"
+            id="send-confirmation-btn"
+            type="button"
+          >
+            <span
+              class="tm-btn__container tm-btn--primary"
+            >
+              <!---->
+              <!---->
+              <span
+                class="tm-btn__value"
+              >
+                Confirm
+              </span>
+            </span>
+          </button>
+        </div>
+      </footer>
     </main>
-    <footer
-      class="tm-modal-footer"
-    >
-      <div>
-        <button
-          class="tm-btn"
-          id="send-cancel-btn"
-          type="button"
-        >
-          <span
-            class="tm-btn__container"
-          >
-            <!---->
-            <!---->
-            <span
-              class="tm-btn__value"
-            >
-              Cancel
-            </span>
-          </span>
-        </button>
-        <button
-          class="tm-btn"
-          id="send-confirmation-btn"
-          type="button"
-        >
-          <span
-            class="tm-btn__container tm-btn--primary"
-          >
-            <!---->
-            <!---->
-            <span
-              class="tm-btn__value"
-            >
-              Confirm
-            </span>
-          </span>
-        </button>
-      </div>
-    </footer>
   </div>
 </div>
 `;


### PR DESCRIPTION
Closes #1321 

_Description:_

- improved styling for tm modal (simpler css, cleaner grid, no line and icon)
- not happy with this ux - i would prefer disabling the buttons and using a tooltip to explain why they are disabled - this approach feels misleading - https://github.com/cosmos/voyager/issues/1601

<img width="750" alt="screen shot 2018-11-19 at 11 04 14 pm" src="https://user-images.githubusercontent.com/6021933/48751064-6f153600-ec50-11e8-91c6-d1e0654b652f.png">


❤️ Thank you!

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

* [x] Added entries in `CHANGELOG.md` with issue # and GitHub username
* [x] Reviewed `Files changed` in the github PR explorer
