### PR TITLE
Reduce modal vote minimum width by 1% per button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [\#1662](https://github.com/cosmos/voyager/issues/1662) Fixed wrong node version in readme @faboweb
 - [\#1641](https://github.com/cosmos/voyager/issues/1641) Fixed styling of validator page (parameters on top and min-width) @faboweb
 - [\#1667](https://github.com/cosmos/voyager/issues/1667) Fixed menu in PageSend + hover cursor for menu @sabau
+- [\#1676](https://github.com/cosmos/voyager/issues/1676) Reduced minWidth css for ModalVote to have 2 buttons per line @sabau
 
 ## [0.10.7] - 2018-10-10
 

--- a/app/src/renderer/components/governance/ModalVote.vue
+++ b/app/src/renderer/components/governance/ModalVote.vue
@@ -194,7 +194,7 @@ export default {
 
 .modal-vote button {
   margin: 0;
-  min-width: 50%;
+  min-width: 49%;
 }
 
 .modal-vote button span {


### PR DESCRIPTION
_Description:_

- left and right 0.25 margin is taking up that space
- 0.5 would have been enough until 1024
- on smaller device buttons have all different size, should we take care of that before web?

Closes #1676 

❤️ Thank you!

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [ ] Added entries in `CHANGELOG.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
