### PR TITLE
Fabo/1670 update balance after gov interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [\#1641](https://github.com/cosmos/voyager/issues/1641) Fixed styling of validator page (parameters on top and min-width) @faboweb
 - [\#1667](https://github.com/cosmos/voyager/issues/1667) Fixed menu in PageSend + hover cursor for menu @sabau
 - [\#1676](https://github.com/cosmos/voyager/issues/1676) Reduced minWidth css for ModalVote to have 2 buttons per line @sabau
+- [\#1676](https://github.com/cosmos/voyager/issues/1670) Update balance in header after voting and depositing @faboweb
 
 ## [0.10.7] - 2018-10-10
 

--- a/app/src/renderer/components/common/TmBalance.vue
+++ b/app/src/renderer/components/common/TmBalance.vue
@@ -6,7 +6,7 @@
       </div>
       <div class="total-atoms top-section">
         <h3>Total {{ bondingDenom }}</h3>
-        <h2>{{ num.shortNumber(totalAtoms) }}</h2>
+        <h2 class="total-atoms__value">{{ num.shortNumber(totalAtoms) }}</h2>
       </div>
       <div v-if="unbondedAtoms" class="unbonded-atoms top-section">
         <h3>Available {{ bondingDenom }}</h3>

--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -159,7 +159,8 @@ export default ({ node }) => {
         `tm.event = 'Tx' AND sender = '${state.address}'`,
         `tm.event = 'Tx' AND recipient = '${state.address}'`,
         `tm.event = 'Tx' AND proposer = '${state.address}'`,
-        `tm.event = 'Tx' AND depositer = '${state.address}'`
+        `tm.event = 'Tx' AND depositer = '${state.address}'`,
+        `tm.event = 'Tx' AND voter = '${state.address}'`
       ]
 
       queries.forEach(query => {

--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -155,19 +155,21 @@ export default ({ node }) => {
         )
       }
 
-      node.rpc.subscribe(
-        {
-          query: `tm.event = 'Tx' AND sender = '${state.address}'`
-        },
-        onTx
-      )
+      const queries = [
+        `tm.event = 'Tx' AND sender = '${state.address}'`,
+        `tm.event = 'Tx' AND recipient = '${state.address}'`,
+        `tm.event = 'Tx' AND proposer = '${state.address}'`,
+        `tm.event = 'Tx' AND depositer = '${state.address}'`
+      ]
 
-      node.rpc.subscribe(
-        {
-          query: `tm.event = 'Tx' AND recipient = '${state.address}'`
-        },
-        onTx
-      )
+      queries.forEach(query => {
+        node.rpc.subscribe(
+          {
+            query
+          },
+          onTx
+        )
+      })
     }
   }
 

--- a/app/src/renderer/vuex/modules/wallet.js
+++ b/app/src/renderer/vuex/modules/wallet.js
@@ -160,6 +160,7 @@ export default ({ node }) => {
         `tm.event = 'Tx' AND recipient = '${state.address}'`,
         `tm.event = 'Tx' AND proposer = '${state.address}'`,
         `tm.event = 'Tx' AND depositer = '${state.address}'`,
+        `tm.event = 'Tx' AND delegator = '${state.address}'`,
         `tm.event = 'Tx' AND voter = '${state.address}'`
       ]
 

--- a/test/e2e/governance.js
+++ b/test/e2e/governance.js
@@ -2,7 +2,12 @@
 
 let test = require(`tape-promise/tape`)
 let { getApp, restart } = require(`./launch.js`)
-let { navigate, login, closeNotifications } = require(`./common.js`)
+let {
+  navigate,
+  login,
+  closeNotifications,
+  waitForText
+} = require(`./common.js`)
 /*
  * NOTE: don't use a global `let client = app.client` as the client object changes when restarting the app
  */
@@ -27,6 +32,9 @@ test(`Governance`, async function(t) {
   })
 
   t.test(`submit proposal`, async function(t) {
+    let balance = parseInt(
+      (await app.client.$(`.total-atoms__value`).getText()).split(`.`)[0]
+    )
     await app.client.$(`#propose-btn`).click()
     await t.ok(
       await app.client.$(`#modal-propose`).isVisible(),
@@ -56,6 +64,11 @@ test(`Governance`, async function(t) {
       `shows the newly created proposal`
     )
     await closeNotifications(app)
+    // check if balance updates accordingly
+    await waitForText(
+      () => app.client.$(`.total-atoms__value`),
+      `${balance - 5}.0000…`
+    )
     t.end()
   })
 
@@ -69,6 +82,9 @@ test(`Governance`, async function(t) {
   })
 
   t.test(`deposit`, async function(t) {
+    let balance = parseInt(
+      (await app.client.$(`.total-atoms__value`).getText()).split(`.`)[0]
+    )
     let deposit = () =>
       $(`//dt[contains(text(), "Deposit")]`)
         .$(`..`)
@@ -101,6 +117,11 @@ test(`Governance`, async function(t) {
       `increments the deposit count displayed on the proposal page`
     )
     await closeNotifications(app)
+    // check if balance updates accordingly
+    await waitForText(
+      () => app.client.$(`.total-atoms__value`),
+      `${balance - 10}.0000…`
+    )
     t.end()
   })
 

--- a/test/unit/specs/components/common/__snapshots__/PagePreferences.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/PagePreferences.spec.js.snap
@@ -41,7 +41,9 @@ exports[`PagePreferences has the expected html structure if connected 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   1,000.0000…
                 </h2>
               </div>

--- a/test/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
@@ -10,7 +10,7 @@ exports[`TmBalance has the expected html structure before adding props 1`] = `
    <h3>
       Total Steak
    </h3>
-   <h2>
+   <h2 class=\\"total-atoms__value\\">
       321.0000…
    </h2>
 </div>

--- a/test/unit/specs/components/governance/__snapshots__/PageGovernance.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageGovernance.spec.js.snap
@@ -17,7 +17,7 @@ exports[`PageGovernance disables proposal creation if not connected 1`] = `
       <h3>
          Total Steak
       </h3>
-      <h2>
+      <h2 class=\\"total-atoms__value\\">
          1,337.0000…
       </h2>
 </div>
@@ -77,7 +77,7 @@ exports[`PageGovernance disables proposal creation if not connected 1`] = `
          <h3>
             Total Steak
          </h3>
-         <h2>
+         <h2 class=\\"total-atoms__value\\">
             1,337.0000…
          </h2>
 </div>
@@ -152,7 +152,7 @@ exports[`PageGovernance has the expected html structure 1`] = `
       <h3>
          Total Steak
       </h3>
-      <h2>
+      <h2 class=\\"total-atoms__value\\">
          1,351.0000…
       </h2>
 </div>
@@ -212,7 +212,7 @@ exports[`PageGovernance has the expected html structure 1`] = `
          <h3>
             Total Steak
          </h3>
-         <h2>
+         <h2 class=\\"total-atoms__value\\">
             1,351.0000…
          </h2>
 </div>

--- a/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
@@ -41,7 +41,9 @@ exports[`PageProposal has the expected html structure 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>
@@ -361,7 +363,9 @@ exports[`PageProposal shows an error if the proposal couldn't be found 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>

--- a/test/unit/specs/components/staking/__snapshots__/PageStaking.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageStaking.spec.js.snap
@@ -17,7 +17,7 @@ exports[`PageStaking has the expected html structure 1`] = `
       <h3>
          Total Steak
       </h3>
-      <h2>
+      <h2 class=\\"total-atoms__value\\">
          1,351.0000…
       </h2>
 </div>
@@ -78,7 +78,7 @@ exports[`PageStaking has the expected html structure 1`] = `
          <h3>
             Total Steak
          </h3>
-         <h2>
+         <h2 class=\\"total-atoms__value\\">
             1,351.0000…
          </h2>
 </div>

--- a/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
@@ -41,7 +41,9 @@ exports[`PageValidator has the expected html structure 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   123.4568…
                 </h2>
               </div>
@@ -558,7 +560,9 @@ exports[`PageValidator shows a default avatar 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   123.4568…
                 </h2>
               </div>
@@ -1057,7 +1061,9 @@ exports[`PageValidator shows an error if the validator couldn't be found 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>
@@ -1272,7 +1278,9 @@ exports[`onDelegation make sure we have enough atoms to delegate is not enough 1
                   Total atom
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   100.0000…
                 </h2>
               </div>
@@ -1782,7 +1790,9 @@ exports[`onDelegation make sure we have enough atoms to delegate is not enough 2
                   Total atom
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   100.0000…
                 </h2>
               </div>
@@ -2224,7 +2234,9 @@ exports[`onUnstake make sure there are enough atoms to unstake is not enough 1`]
                   Total atom
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   100.0000…
                 </h2>
               </div>
@@ -2734,7 +2746,9 @@ exports[`onUnstake make sure there are enough atoms to unstake is not enough 2`]
                   Total atom
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   100.0000…
                 </h2>
               </div>

--- a/test/unit/specs/components/wallet/__snapshots__/PageSend.spec.js.snap
+++ b/test/unit/specs/components/wallet/__snapshots__/PageSend.spec.js.snap
@@ -41,7 +41,9 @@ exports[`PageSend disables sending if not connected 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   1,000.0000…
                 </h2>
               </div>
@@ -455,7 +457,9 @@ exports[`PageSend has the expected html structure 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   1,000.0000…
                 </h2>
               </div>
@@ -893,7 +897,9 @@ exports[`PageSend should show address required error 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>
@@ -1305,7 +1311,9 @@ exports[`PageSend should show bech32 error when address length is too long 1`] =
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>
@@ -1717,7 +1725,9 @@ exports[`PageSend should show bech32 error when address length is too short 1`] 
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>
@@ -2129,7 +2139,9 @@ exports[`PageSend should show bech32 error when alphanumeric is wrong 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>
@@ -2552,7 +2564,9 @@ exports[`PageSend should trigger confirmation modal if form is correct 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>
@@ -3064,7 +3078,9 @@ exports[`PageSend should work without providing a default denom 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>

--- a/test/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
+++ b/test/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
@@ -41,7 +41,9 @@ exports[`PageTransactions has the expected html structure 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>
@@ -270,7 +272,9 @@ exports[`PageTransactions should filter the transactions 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   0.0000…
                 </h2>
               </div>

--- a/test/unit/specs/components/wallet/__snapshots__/PageWallet.spec.js.snap
+++ b/test/unit/specs/components/wallet/__snapshots__/PageWallet.spec.js.snap
@@ -41,7 +41,9 @@ exports[`PageWallet has the expected html structure 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   1,014.0000…
                 </h2>
               </div>
@@ -418,7 +420,9 @@ exports[`PageWallet should filter the balances 1`] = `
                   Total Steak
                 </h3>
                  
-                <h2>
+                <h2
+                  class="total-atoms__value"
+                >
                   1,014.0000…
                 </h2>
               </div>

--- a/test/unit/specs/store/__snapshots__/wallet.spec.js.snap
+++ b/test/unit/specs/store/__snapshots__/wallet.spec.js.snap
@@ -22,6 +22,10 @@ Array [
     "error subscribing to transactions",
     [Error: foo],
   ],
+  Array [
+    "error subscribing to transactions",
+    [Error: foo],
+  ],
 ]
 `;
 

--- a/test/unit/specs/store/__snapshots__/wallet.spec.js.snap
+++ b/test/unit/specs/store/__snapshots__/wallet.spec.js.snap
@@ -10,6 +10,18 @@ Array [
     "error subscribing to transactions",
     [Error: foo],
   ],
+  Array [
+    "error subscribing to transactions",
+    [Error: foo],
+  ],
+  Array [
+    "error subscribing to transactions",
+    [Error: foo],
+  ],
+  Array [
+    "error subscribing to transactions",
+    [Error: foo],
+  ],
 ]
 `;
 


### PR DESCRIPTION
Closes #1670

_Description:_

Voyager is now querying the balance after any tx with a "sender", "depositer", "voter", "proposer" or "recipient" tag with the account of the currently logged in user.

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [ ] Added entries in `CHANGELOG.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
