### PR TITLE
Avoid double voting with same option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [\#1681](https://github.com/cosmos/voyager/issues/1681) Governance: Fixed voting starting date @sabau
 - [\#1690](https://github.com/cosmos/voyager/issues/1690) Governance: Fixed error messages for maxLength @sabau
 - [\#1690](https://github.com/cosmos/voyager/issues/1690) Feedbacks when Amount is not between valid thresholds @sabau
+- [\#1683](https://github.com/cosmos/voyager/issues/1683) Governance: block voting twice for the same option @sabau
 
 ### Changed
 

--- a/app/src/renderer/components/governance/ModalVote.vue
+++ b/app/src/renderer/components/governance/ModalVote.vue
@@ -17,6 +17,7 @@
       <tm-btn
         id="vote-yes"
         :class="[option === `Yes` ? 'active' : '']"
+        :disabled="lastVoteOption === `Yes`"
         color="secondary"
         value="Yes"
         size="md"
@@ -25,6 +26,7 @@
       <tm-btn
         id="vote-no"
         :class="[option === `No` ? 'active' : '']"
+        :disabled="lastVoteOption === `No`"
         color="secondary"
         value="No"
         size="md"
@@ -33,6 +35,7 @@
       <tm-btn
         id="vote-veto"
         :class="[option === `NoWithVeto` ? 'active' : '']"
+        :disabled="lastVoteOption === `NoWithVeto`"
         color="secondary"
         value="No With Veto"
         size="md"
@@ -41,6 +44,7 @@
       <tm-btn
         id="vote-abstain"
         :class="[option === `Abstain` ? 'active' : '']"
+        :disabled="lastVoteOption === `Abstain`"
         color="secondary"
         value="Abstain"
         size="md"
@@ -113,6 +117,11 @@ export default {
     proposalTitle: {
       type: String,
       required: true
+    },
+    lastVoteOption: {
+      default: undefined,
+      type: String,
+      required: false
     }
   },
   data: () => ({

--- a/app/src/renderer/components/governance/PageProposal.vue
+++ b/app/src/renderer/components/governance/PageProposal.vue
@@ -255,17 +255,11 @@ export default {
     async onVote() {
       this.showModalVote = true
 
-      try {
-        await this.$store.dispatch(`getProposalVotes`, this.proposalId)
-        this.lastVote =
-          this.votes[this.proposalId] &&
-          this.votes[this.proposalId].find(e => e.voter === this.wallet.address)
-      } catch ({ message }) {
-        this.$store.commit(`notifyError`, {
-          title: `Error while getting votes for proposal #${this.proposalId}`,
-          body: message
-        })
-      }
+      // The error is already handled with notifyError in votes.js
+      await this.$store.dispatch(`getProposalVotes`, this.proposalId)
+      this.lastVote =
+        this.votes[this.proposalId] &&
+        this.votes[this.proposalId].find(e => e.voter === this.wallet.address)
     },
     onDeposit() {
       this.showModalDeposit = true

--- a/app/src/renderer/connectors/lcdClientMock.js
+++ b/app/src/renderer/connectors/lcdClientMock.js
@@ -1184,8 +1184,11 @@ module.exports = {
     results.push(txResult(0))
     return results
   },
-  async getProposalVotes(proposalId) {
-    return state.votes[proposalId] || []
+  async queryProposalVotes(proposalId) {
+    return (
+      state.votes[proposalId] ||
+      Promise.reject(`Invalid proposalId ${proposalId}`)
+    )
   },
   async submitProposalVote({
     proposal_id,

--- a/app/src/renderer/connectors/lcdClientMock.js
+++ b/app/src/renderer/connectors/lcdClientMock.js
@@ -1187,7 +1187,7 @@ module.exports = {
   async queryProposalVotes(proposalId) {
     return (
       state.votes[proposalId] ||
-      Promise.reject(`Invalid proposalId ${proposalId}`)
+      Promise.reject({ message: `Invalid proposalId #${proposalId}` })
     )
   },
   async submitProposalVote({

--- a/app/src/renderer/vuex/modules/governance/votes.js
+++ b/app/src/renderer/vuex/modules/governance/votes.js
@@ -1,4 +1,5 @@
 import Raven from "raven-js"
+import Vue from "vue"
 
 export default ({ node }) => {
   const state = {
@@ -9,8 +10,8 @@ export default ({ node }) => {
   }
 
   const mutations = {
-    setProposalVotes(state, proposalId, votes) {
-      state.votes[proposalId] = votes
+    setProposalVotes(state, { proposalId, votes }) {
+      Vue.set(state.votes, proposalId, votes)
     }
   }
   let actions = {
@@ -21,7 +22,7 @@ export default ({ node }) => {
 
       try {
         let votes = await node.queryProposalVotes(proposalId)
-        commit(`setProposalVotes`, proposalId, votes)
+        commit(`setProposalVotes`, { proposalId, votes })
         state.error = null
         state.loading = false
         state.loaded = true

--- a/test/unit/specs/components/governance/ModalVote.spec.js
+++ b/test/unit/specs/components/governance/ModalVote.spec.js
@@ -92,6 +92,20 @@ describe(`ModalVote`, () => {
     })
   })
 
+  describe(`Disable already voted options`, () => {
+    it(`disable button if equals the last vote: Abstain`, () => {
+      wrapper.setProps({ lastVoteOption: `Abstain` })
+      let voteBtn = wrapper.find(`#vote-yes`)
+      expect(voteBtn.html()).not.toContain(`disabled="disabled"`)
+      voteBtn = wrapper.find(`#vote-no`)
+      expect(voteBtn.html()).not.toContain(`disabled="disabled"`)
+      voteBtn = wrapper.find(`#vote-veto`)
+      expect(voteBtn.html()).not.toContain(`disabled="disabled"`)
+      voteBtn = wrapper.find(`#vote-abstain`)
+      expect(voteBtn.html()).toContain(`disabled="disabled"`)
+    })
+  })
+
   describe(`closes modal correctly`, () => {
     it(`X button emits close signal`, () => {
       wrapper.vm.close()

--- a/test/unit/specs/components/governance/PageProposal.spec.js
+++ b/test/unit/specs/components/governance/PageProposal.spec.js
@@ -147,8 +147,35 @@ describe(`PageProposal`, () => {
       expect(wrapper.vm.$store.dispatch.mock.calls).toEqual([
         [`getProposalVotes`, proposal.proposal_id]
       ])
+      expect(wrapper.vm.lastVote).not.toBeDefined()
       expect(wrapper.contains(ModalVote)).toEqual(true)
       expect(voteBtn.html()).not.toContain(`disabled="disabled"`)
+    })
+
+    it(`load the last valid vote succesfully`, async () => {
+      wrapper.setProps({ proposalId: `1` })
+      wrapper.vm.wallet.address = lcdClientMock.state.votes[`1`][0].voter
+      await wrapper.vm.onVote()
+      expect(wrapper.vm.$store.dispatch.mock.calls).toEqual([
+        [`getProposalVotes`, `1`]
+      ])
+      expect(wrapper.vm.lastVote).toBe(lcdClientMock.state.votes[`1`][0])
+    })
+
+    it(`keeps the last vote undefined if no vote to this proposal happened from the current address`, async () => {
+      wrapper.setProps({ proposalId: `2` })
+      await wrapper.vm.onVote()
+      expect(wrapper.vm.$store.dispatch.mock.calls).toEqual([
+        [`getProposalVotes`, `2`]
+      ])
+      expect(wrapper.vm.lastVote).toBe(undefined)
+    })
+
+    it(`throws an error when trying to fetch a wrong proposalId votes`, async () => {
+      wrapper.setProps({ proposalId: `3` })
+      await wrapper.vm.onVote()
+      expect(store.state.notifications.length).toBe(1)
+      expect(store.state.notifications[0].title).toBe(`Error fetching votes`)
     })
 
     it(`disables voting if the proposal is on the 'DepositPeriod'`, () => {

--- a/test/unit/specs/components/governance/PageProposal.spec.js
+++ b/test/unit/specs/components/governance/PageProposal.spec.js
@@ -122,7 +122,7 @@ describe(`PageProposal`, () => {
   })
 
   describe(`Modal onVote`, () => {
-    it(`enables voting if the proposal is on the 'VotingPeriod'`, () => {
+    it(`enables voting if the proposal is on the 'VotingPeriod'`, async () => {
       let proposal = lcdClientMock.state.proposals[1]
       let instance = mount(PageProposal, {
         localVue,
@@ -140,8 +140,13 @@ describe(`PageProposal`, () => {
       store = instance.store
       wrapper.update()
 
+      wrapper.vm.$store.dispatch = jest.fn()
       let voteBtn = wrapper.find(`#vote-btn`)
       voteBtn.trigger(`click`)
+
+      expect(wrapper.vm.$store.dispatch.mock.calls).toEqual([
+        [`getProposalVotes`, proposal.proposal_id]
+      ])
       expect(wrapper.contains(ModalVote)).toEqual(true)
       expect(voteBtn.html()).not.toContain(`disabled="disabled"`)
     })

--- a/test/unit/specs/lcdClientMock.spec.js
+++ b/test/unit/specs/lcdClientMock.spec.js
@@ -1298,7 +1298,7 @@ describe(`LCD Client Mock`, () => {
     describe(`Votes`, () => {
       it(`queries a proposal votes`, async () => {
         let { votes } = lcdClientMock.state
-        let votesRes = await client.getProposalVotes(`1`)
+        let votesRes = await client.queryProposalVotes(`1`)
         expect(votesRes).toBeDefined()
         expect(votesRes).toEqual(votes[`1`])
       })

--- a/test/unit/specs/store/governance/votes.spec.js
+++ b/test/unit/specs/store/governance/votes.spec.js
@@ -22,10 +22,10 @@ describe(`Module: Votes`, () => {
   it(`adds votes to state`, () => {
     let { mutations, state } = module
     mutations.setProposalVotes(state, {
-      proposalId: proposals[`1`].proposal_id,
+      proposalId: `1`,
       votes
     })
-    expect(state.votes[proposals[`1`].proposal_id]).toEqual(votes)
+    expect(state.votes[`1`]).toEqual(votes)
   })
 
   it(`fetches all votes from a proposal`, async () => {

--- a/test/unit/specs/store/governance/votes.spec.js
+++ b/test/unit/specs/store/governance/votes.spec.js
@@ -21,7 +21,10 @@ describe(`Module: Votes`, () => {
 
   it(`adds votes to state`, () => {
     let { mutations, state } = module
-    mutations.setProposalVotes(state, proposals[0].proposal_id, votes)
+    mutations.setProposalVotes(state, {
+      proposalId: proposals[0].proposal_id,
+      votes
+    })
     expect(state.votes[proposals[0].proposal_id]).toEqual(votes)
   })
 
@@ -34,15 +37,17 @@ describe(`Module: Votes`, () => {
     let { actions, state } = module
     let commit = jest.fn()
     proposals.forEach(async (proposal, i) => {
-      let proposalID = proposal.proposal_id
+      let proposalId = proposal.proposal_id
       await actions.getProposalVotes(
         { state, commit, rootState: mockRootState },
-        proposalID
+        proposalId
       )
       expect(commit.mock.calls[i]).toEqual([
         `setProposalVotes`,
-        proposalID,
-        votes[proposalID]
+        {
+          proposalId,
+          votes: votes[proposalId]
+        }
       ])
     })
   })


### PR DESCRIPTION


_Description:_
- getVotes has been used instead of getVote as the latter throws error if the specified address did't vote yet
- disable the already voted option
- fixed setProposalVotes action parameters

Closes #1683

❤️ Thank you!

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [ ] Added entries in `CHANGELOG.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
