### PR TITLE
1724 tab navigation for ModalProposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [\#1638](https://github.com/cosmos/voyager/issues/1638) removed account password from the state and now user has to input it on every transaction @fedekunze
 - [\#1655](https://github.com/cosmos/voyager/issues/1655) Text and Textarea fields trimmed @sabau
 - [\#1686](https://github.com/cosmos/voyager/issues/1686) Changed proposals from array to object @sabau
-- [\#1724](https://github.com/cosmos/voyager/issues/1724) set tabindex attribute to -1 for readonly denom. tab navgiation now skips element @enyan94
+- [\#1724](https://github.com/cosmos/voyager/issues/1724) set tabindex attribute to -1 for readonly denom on ModalProposals. tab navgiation now skips element @enyan94
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [\#1638](https://github.com/cosmos/voyager/issues/1638) removed account password from the state and now user has to input it on every transaction @fedekunze
 - [\#1655](https://github.com/cosmos/voyager/issues/1655) Text and Textarea fields trimmed @sabau
 - [\#1686](https://github.com/cosmos/voyager/issues/1686) Changed proposals from array to object @sabau
+- [\#1724](https://github.com/cosmos/voyager/issues/1724) set tabindex attribute to -1 for readonly denom. tab navgiation now skips element @enyan94
 
 ### Fixed
 

--- a/app/src/renderer/components/governance/ModalPropose.vue
+++ b/app/src/renderer/components/governance/ModalPropose.vue
@@ -53,6 +53,7 @@
         id="denom"
         :placeholder="denom"
         type="text"
+        :tabindex="-1"
         readonly="readonly"
       />
       <tm-field

--- a/app/src/renderer/components/governance/ModalPropose.vue
+++ b/app/src/renderer/components/governance/ModalPropose.vue
@@ -52,8 +52,8 @@
       <tm-field
         id="denom"
         :placeholder="denom"
-        type="text"
         :tabindex="-1"
+        type="text"
         readonly="readonly"
       />
       <tm-field

--- a/test/unit/specs/components/governance/__snapshots__/ModalPropose.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/ModalPropose.spec.js.snap
@@ -92,6 +92,7 @@ exports[`ModalPropose component matches snapshot has the expected html structure
         id="denom"
         placeholder="stake"
         readonly="readonly"
+        tabindex="-1"
         type="text"
       />
        


### PR DESCRIPTION
Part of #1724 

Tab navigation now skips readonly denom in ModalProposals. This seems to be the only readonly element that was causing "improper" tab navigation.