### PR TITLE
Fabo/1791 fix voyager init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [\#1572](https://github.com/cosmos/voyager/issues/1572) Fixed scroll bug when switching between tabs @jbibla
 - [\#1749](https://github.com/cosmos/voyager/issues/1749) Fixed proposal tally update after voting @fedekunze
 - [\#1765](https://github.com/cosmos/voyager/pull/1765) Fixed proposal deposit update after submitting a deposit @fedekunze
+- [\#1791](https://github.com/cosmos/voyager/pull/1791) Fixed a problem with initializing the Voyager config dir @fedekunze
 
 ## [0.10.7] - 2018-10-10
 

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -656,7 +656,18 @@ async function main() {
 
     // copy predefined genesis.json and config.toml into root
     fs.accessSync(networkPath) // crash if invalid path
-    fs.copySync(networkPath, root)
+    await fs.copyFile(
+      join(networkPath, `config.toml`),
+      join(root, `config.toml`)
+    )
+    await fs.copyFile(
+      join(networkPath, `gaiaversion.txt`),
+      join(root, `gaiaversion.txt`)
+    )
+    await fs.copyFile(
+      join(networkPath, `genesis.json`),
+      join(root, `genesis.json`)
+    )
 
     fs.writeFileSync(appVersionPath, pkgVersion)
   }

--- a/test/unit/helpers/fs-mock.js
+++ b/test/unit/helpers/fs-mock.js
@@ -15,6 +15,7 @@ export default function mockFsExtra(fileSystem = {}) {
       }
       create(to, fsExtraMock.fs, file)
     },
+    copyFile: (from, to) => fsExtraMock.copy(from, to),
     ensureFile: path => {
       let { file } = get(path, fsExtraMock.fs)
       if (file === null) {


### PR DESCRIPTION
Closes #1791 

_Description:_

Copying folders for downloaded testnets may lead to copy loops of folders into folders etc.
Cherrypicking only the needed files seems safer here

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [ ] Added entries in `CHANGELOG.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
