### PR TITLE
Change time format to 24h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [\#1432](https://github.com/cosmos/voyager/issues/1432) Moved @tendermint/UI components back into the Voyager repository @faboweb
 - Improved the readme @faboweb
 - [\#1792](https://github.com/cosmos/voyager/pull/1792) removed mocked demo mode @fedekunze
+- [\#1720](https://github.com/cosmos/voyager/issues/1720) Time format from 12 to 24h @sabau
 
 ### Fixed
 

--- a/app/src/renderer/components/transactions/TmLiTransaction.vue
+++ b/app/src/renderer/components/transactions/TmLiTransaction.vue
@@ -47,7 +47,10 @@ export default {
   },
   computed: {
     date() {
-      return moment(this.time).format(`HH:mm`)
+      const time = moment(this.time)
+      return time.format(
+        `${moment().isSame(time, `day`) ? `` : `YYYY/MM/DD `}HH:mm`
+      )
     }
   }
 }

--- a/app/src/renderer/components/transactions/TmLiTransaction.vue
+++ b/app/src/renderer/components/transactions/TmLiTransaction.vue
@@ -47,7 +47,7 @@ export default {
   },
   computed: {
     date() {
-      return moment(this.time).format(`h:mm a`)
+      return moment(this.time).format(`HH:mm`)
     }
   }
 }

--- a/app/src/renderer/vuex/modules/transactions.js
+++ b/app/src/renderer/vuex/modules/transactions.js
@@ -33,7 +33,8 @@ export default ({ node }) => {
       txCategories.forEach(category => {
         state[category].forEach(t => {
           if (t.height === blockHeight && blockMetaInfo) {
-            Vue.set(t, `time`, blockMetaInfo.header.time)
+            // time seems to be an ISO string, but we are expecting a Number type
+            Vue.set(t, `time`, new Date(blockMetaInfo.header.time).getTime())
           }
         })
       })

--- a/app/src/renderer/vuex/modules/transactions.js
+++ b/app/src/renderer/vuex/modules/transactions.js
@@ -108,7 +108,9 @@ export default ({ node }) => {
       return response ? uniqBy(transactionsPlusType, `hash`) : []
     },
     async enrichTransactions({ dispatch }, { transactions }) {
-      const blockHeights = new Set(transactions.map(({ height }) => height))
+      const blockHeights = new Set(
+        transactions.map(({ height }) => parseInt(height))
+      )
       await Promise.all(
         [...blockHeights].map(blockHeight =>
           dispatch(`queryTransactionTime`, { blockHeight })

--- a/test/unit/specs/components/transactions/__snapshots__/TmLiAnyTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/TmLiAnyTransaction.spec.js.snap
@@ -55,7 +55,7 @@ exports[`TmLiAnyTransaction shows bank transactions 1`] = `
       >
         Block #3436 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>
@@ -123,7 +123,7 @@ exports[`TmLiAnyTransaction shows stake transactions 1`] = `
       >
         Block #568 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>
@@ -173,7 +173,7 @@ exports[`TmLiAnyTransaction shows unknown transactions 1`] = `
       >
         Block #3436 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>

--- a/test/unit/specs/components/transactions/__snapshots__/TmLiGovTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/TmLiGovTransaction.spec.js.snap
@@ -66,7 +66,7 @@ exports[`TmLiGovTransaction deposits should show deposits 1`] = `
       >
         Block #56675 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>
@@ -133,7 +133,7 @@ exports[`TmLiGovTransaction proposals should show proposals submission transacti
       >
         Block #56673 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>

--- a/test/unit/specs/components/transactions/__snapshots__/TmLiStakeTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/TmLiStakeTransaction.spec.js.snap
@@ -61,7 +61,7 @@ exports[`TmLiStakeTransaction delegations should show delegations 1`] = `
       >
         Block #568 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>
@@ -136,7 +136,7 @@ exports[`TmLiStakeTransaction redelegations should show redelegations and calcul
       >
         Block #567 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>
@@ -205,7 +205,7 @@ exports[`TmLiStakeTransaction unbonding delegations should default to ended if n
       >
         Block #569 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>
@@ -274,7 +274,7 @@ exports[`TmLiStakeTransaction unbonding delegations should show unbonding delega
       >
         Block #569 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>
@@ -347,7 +347,7 @@ exports[`TmLiStakeTransaction unbonding delegations should show unbondings and c
       >
         Block #569 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>

--- a/test/unit/specs/components/transactions/__snapshots__/TmLiTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/TmLiTransaction.spec.js.snap
@@ -48,7 +48,7 @@ exports[`TmLiTransaction has the expected html structure 1`] = `
       >
         Block #500 
       </a>
-      @ 12:00 am
+      @ 00:00
     
     </div>
   </div>

--- a/test/unit/specs/store/__snapshots__/transactions.spec.js.snap
+++ b/test/unit/specs/store/__snapshots__/transactions.spec.js.snap
@@ -731,7 +731,7 @@ Array [
   Object {
     "hash": "A7C6DE5CB923AF08E6088F1348047F16BABB9F48",
     "height": 160,
-    "time": 10160,
+    "time": 42000,
     "tx": Object {
       "value": Object {
         "msg": Array [
@@ -754,7 +754,7 @@ Array [
   Object {
     "hash": "A7C6FDE5CA923AF08E6088F1348047F16BABB9F48",
     "height": 170,
-    "time": 10170,
+    "time": 42000,
     "tx": Object {
       "value": Object {
         "msg": Array [

--- a/test/unit/specs/store/transactions.spec.js
+++ b/test/unit/specs/store/transactions.spec.js
@@ -50,13 +50,13 @@ describe(`Module: Transactions`, () => {
       blockHeight: `3436`,
       blockMetaInfo: {
         header: {
-          time: 1042
+          time: 42000
         }
       }
     })
     expect(
       store.state.transactions.wallet.find(tx => tx.height === `3436`).time
-    ).toBe(1042)
+    ).toBe(42000)
   })
 
   it(`should clear session data`, () => {


### PR DESCRIPTION
Closes #1720 

_Description:_

- change time format for Transactions from 12 to 24H
- change times in tests to agree with fixed-time
- fix transactions enrichment to match props expectations

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [ ] Added entries in `CHANGELOG.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
