### PR TITLE
Fabo/1818 fix validators message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [\#1707](https://github.com/cosmos/voyager/issues/1707) Governance txs are now disabled if the user doesn't hold any min_deposit token @fedekunze
 - [\#1815](https://github.com/cosmos/voyager/pull/1815) Fixed getters for proposals denominator, reverted to 945803d586b83d65547cd16f4cd5994eac2957ea until interfaces are ready @sabau
 - Fixed build process @ƒaboweb
+- [\#1818](https://github.com/cosmos/voyager/issues/1818) Fixed error on validator loading showing as no validators @faboweb
 
 ## [0.10.7] - 2018-10-10
 

--- a/app/src/renderer/vuex/modules/delegates.js
+++ b/app/src/renderer/vuex/modules/delegates.js
@@ -107,7 +107,6 @@ export default ({ node }) => {
           body: error.message
         })
         Sentry.captureException(error)
-        commit(`setDelegateLoading`, false)
         state.error = error
         return []
       }

--- a/test/unit/specs/store/delegates.spec.js
+++ b/test/unit/specs/store/delegates.spec.js
@@ -96,6 +96,29 @@ describe(`Module: Delegates`, () => {
     ])
   })
 
+  it(`keeps the loading state if loading failed`, async () => {
+    let { actions, state } = module
+    let commit = jest.fn()
+    let dispatch = jest.fn()
+    node.getCandidates = () => Promise.reject(new Error(`Expected`))
+    await actions.getDelegates({
+      state,
+      commit,
+      dispatch,
+      rootState: mockRootState
+    })
+    expect(commit.mock.calls).toEqual([
+      [`setDelegateLoading`, true],
+      [
+        `notifyError`,
+        {
+          body: `Expected`,
+          title: `Error fetching validators`
+        }
+      ]
+    ])
+  })
+
   it(`should query further info for validators`, async () => {
     let { actions, state } = module
     let commit = jest.fn()


### PR DESCRIPTION
Closes #1818

_Description:_

On error the module would set `loading` to false. But on error `loading` should stay `true` to indicate the pending loading.

<!-- Briefly describe what you're adding or fixing with this PR -->

❤️ Thank you!

---

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                    Thanks for creating a PR!
v    Before smashing the submit button please review the checkboxes
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [ ] Added entries in `CHANGELOG.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
