### PR TITLE
Redirecting dependency to cosmos repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Refactored user and session modules @faboweb
 - Made app header and menu states local @faboweb
 - [\#1993](https://github.com/cosmos/voyager/issues/1993) disabled web wallet in production @faboweb
+- [\#2031](https://github.com/cosmos/voyager/issues/2031) voyager now depends from cosmos/ledger-cosmos-js
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "fs-extra": "7.0.0",
     "glob": "7.1.3",
     "js-beautify": "1.8.6",
-    "ledger-cosmos-js": "https://github.com/ZondaX/ledger-cosmos-js",
+    "ledger-cosmos-js": "https://github.com/cosmos/ledger-cosmos-js",
     "markdown-it-anchor": "5.0.2",
     "moment": "2.22.1",
     "mousetrap": "1.6.1",


### PR DESCRIPTION
Closes #2031 

**Description:**

Now voyager will point directly to cosmos/ledger-cosmos-js

---

For contributor:

- [ ] Added entries in `CHANGELOG.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
