### PR TITLE
Fabo/dispatch reconnected event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [\#1630](https://github.com/cosmos/voyager/issues/1630) added memo "Sent via Cosmos UI" to distinguish txs sent via UI @faboweb
 
+### Fixed
+
+- Reconnected event was not triggered after reconnection @faboweb
+
 ## [1.0.0-beta.7] - 2019-02-26
 
 ### Changed

--- a/app/src/renderer/vuex/modules/connection.js
+++ b/app/src/renderer/vuex/modules/connection.js
@@ -50,6 +50,7 @@ export default function({ node }) {
       try {
         await node.rpcConnect(rpcUrl)
         commit(`setConnected`, true)
+        dispatch(`reconnected`)
         dispatch(`rpcSubscribe`)
         dispatch(`subscribeToBlocks`)
       } catch (err) {

--- a/test/unit/specs/store/connection.spec.js
+++ b/test/unit/specs/store/connection.spec.js
@@ -94,15 +94,22 @@ describe(`Module: Connection`, () => {
     })
   })
 
-  it(`triggers a reconnect`, () => {
+  it(`triggers a reconnect`, async () => {
     const commit = jest.fn()
-    actions.connect({
+    const dispatch = jest.fn()
+    await actions.connect({
       state,
-      commit
+      commit,
+      dispatch
     })
 
     expect(commit).toHaveBeenCalledWith(`setConnected`, false)
     expect(node.rpcConnect).toHaveBeenCalled()
+
+    // on success should trigger connection follow up events
+    expect(dispatch).toHaveBeenCalledWith(`reconnected`)
+    expect(dispatch).toHaveBeenCalledWith(`rpcSubscribe`)
+    expect(dispatch).toHaveBeenCalledWith(`subscribeToBlocks`)
   })
 
   it(`should not reconnect if stop reconnecting is set`, () => {


### PR DESCRIPTION
The "reconnected" event was not dispatched on a reconnect