### PR TITLE
Jordan/2179 removed the "to" field on undelegation action modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - [\#1897](https://github.com/cosmos/voyager/issues/1897) made action modals smaller @jbibla
+- [\#2179](https://github.com/cosmos/voyager/issues/2179) removed "to" field from undelegation action modal @jbibla
 
 ## [1.0.0-beta.13] - 2019-03-05
 

--- a/app/src/renderer/components/staking/UndelegationModal.vue
+++ b/app/src/renderer/components/staking/UndelegationModal.vue
@@ -17,13 +17,6 @@
       <tm-field id="from" v-model="validator.operator_address" readonly />
     </tm-form-group>
     <tm-form-group
-      class="action-modal-form-group"
-      field-id="to"
-      field-label="To"
-    >
-      <tm-field id="to" v-model="to" readonly="readonly" />
-    </tm-form-group>
-    <tm-form-group
       :error="$v.amount.$error && $v.amount.$invalid"
       class="action-modal-form-group"
       field-id="amount"

--- a/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
@@ -24,19 +24,6 @@ exports[`UndelegationModal component matches snapshot has the expected html stru
    
   <tm-form-group-stub
     class="action-modal-form-group"
-    fieldid="to"
-    fieldlabel="To"
-  >
-    <tm-field-stub
-      id="to"
-      readonly="readonly"
-      type="text"
-      value="cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctplpn3au"
-    />
-  </tm-form-group-stub>
-   
-  <tm-form-group-stub
-    class="action-modal-form-group"
     fieldid="amount"
     fieldlabel="Amount"
   >


### PR DESCRIPTION
Closes #2179 

**Description:**

- removed the "to" field on undelegation action modals

Thank you! 🚀

---

For contributor:

- [ ] Added entries in `CHANGELOG.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
