### PR TITLE
fix atoms <––> uatoms conversion

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -5,7 +5,8 @@
 ### Fixed
 
 - Fix for inflation on our testnet
-- [\#2257](https://github.com/cosmos/voyager/pull/2257) fixed console error on page validator if loading the page from URL @faboweb
+- [\#2257](https://github.com/cosmos/voyager/pull/2257) fixed console
+- [\#2273](https://github.com/cosmos/voyager/issues/2273) fixed atoms and uatoms conversion @fedekunze
 
 ### Changed
 

--- a/app/src/renderer/scripts/num.js
+++ b/app/src/renderer/scripts/num.js
@@ -6,10 +6,10 @@ import BigNumber from "bignumber.js"
  * @module num
  */
 
-const SMALLEST = 1e-7
+const SMALLEST = 1e-6
 const language = window.navigator.userLanguage || window.navigator.language
 function full(number = 0) {
-  return new Intl.NumberFormat(language, { minimumFractionDigits: 7 })
+  return new Intl.NumberFormat(language, { minimumFractionDigits: 6 })
     .format(number)
 }
 function shortNumber(number = 0) {

--- a/app/src/renderer/scripts/num.js
+++ b/app/src/renderer/scripts/num.js
@@ -29,12 +29,12 @@ function prettyDecimals(number = 0) {
   ).format(number)
 
   // remove all trailing zeros
-  while(longDecimals.charAt(longDecimals.length - 1) === `0`) {
+  while (longDecimals.charAt(longDecimals.length - 1) === `0`) {
     longDecimals = longDecimals.substr(0, longDecimals.length - 1)
   }
 
   // remove decimal separator from whole numbers
-  if(Number.isNaN(Number(longDecimals.charAt(longDecimals.length - 1)))) {
+  if (Number.isNaN(Number(longDecimals.charAt(longDecimals.length - 1)))) {
     longDecimals = longDecimals.substr(0, longDecimals.length - 1)
   }
 
@@ -53,10 +53,10 @@ function percent(number = 0) {
   ).format(Math.round(number * 10000) / 100) + `%`
 }
 function atoms(number = 0) {
-  return BigNumber(number).div(10e6).toNumber()
+  return BigNumber(number).div(1e6).toNumber()
 }
 function uatoms(number = 0) {
-  return BigNumber(number).times(10e6).toString()
+  return BigNumber(number).times(1e6).toString()
 }
 
 module.exports = {

--- a/test/unit/specs/components/common/TmBalance.spec.js
+++ b/test/unit/specs/components/common/TmBalance.spec.js
@@ -35,10 +35,10 @@ describe(`TmBalance`, () => {
   })
 
   it(`displays unbonded tokens`, () => {
-    expect(wrapper.vm.unbondedAtoms).toBe(`123.0000…`)
+    expect(wrapper.vm.unbondedAtoms).toBe(`1,230.0000…`)
   })
   it(`gets user rewards`, () => {
-    expect(wrapper.vm.rewards).toBe(`100,045.0000…`)
+    expect(wrapper.vm.rewards).toBe(`1,000,450.0000…`)
   })
 
   it(`shows 0 if user doesn't have rewards`, () => {

--- a/test/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
@@ -27,7 +27,7 @@ exports[`TmBalance has the expected html structure before adding props 1`] = `
         class="total-atoms__value"
       >
         
-        321.0000…
+        3,210.0000…
       
       </h2>
        
@@ -44,7 +44,7 @@ exports[`TmBalance has the expected html structure before adding props 1`] = `
       </h3>
        
       <h2>
-        123.0000…
+        1,230.0000…
       </h2>
     </div>
      
@@ -56,7 +56,7 @@ exports[`TmBalance has the expected html structure before adding props 1`] = `
       </h3>
        
       <h2>
-        100,045.0000…
+        1,000,450.0000…
       </h2>
        
       <tm-btn-stub

--- a/test/unit/specs/components/governance/ModalDeposit.spec.js
+++ b/test/unit/specs/components/governance/ModalDeposit.spec.js
@@ -9,8 +9,8 @@ describe(`ModalDeposit`, () => {
   let wrapper, store
   const { mount, localVue } = setup()
   localVue.use(Vuelidate)
-  localVue.directive(`tooltip`, () => {})
-  localVue.directive(`focus`, () => {})
+  localVue.directive(`tooltip`, () => { })
+  localVue.directive(`focus`, () => { })
 
   beforeEach(async () => {
     const coins = [
@@ -68,7 +68,7 @@ describe(`ModalDeposit`, () => {
       })
 
       it(`when the amount deposited higher than the user's balance`, async () => {
-        wrapper.setData({ amount: 25 })
+        wrapper.setData({ amount: 250 })
         expect(wrapper.vm.validateForm()).toBe(false)
         await wrapper.vm.$nextTick()
         const errorMessage = wrapper.find(`input#amount + div`)
@@ -110,7 +110,7 @@ describe(`ModalDeposit`, () => {
           {
             amount: [
               {
-                amount: `100000000`,
+                amount: `10000000`,
                 denom: `stake`
               }
             ],

--- a/test/unit/specs/components/governance/ModalPropose.spec.js
+++ b/test/unit/specs/components/governance/ModalPropose.spec.js
@@ -83,7 +83,7 @@ describe(`ModalPropose`, () => {
 
       it(`if the amount for initial deposit is higher than the user's balance`, async () => {
         wrapper.setData(inputs)
-        wrapper.setData({ amount: 25 })
+        wrapper.setData({ amount: 250 })
         await wrapper.vm.$nextTick()
         expect(wrapper.vm.validateForm()).toBe(false)
         await wrapper.vm.$nextTick()
@@ -162,7 +162,7 @@ describe(`ModalPropose`, () => {
           `submitProposal`,
           {
             description: `a valid description for the proposal`,
-            initial_deposit: [{ amount: `150000000`, denom: `stake` }],
+            initial_deposit: [{ amount: `15000000`, denom: `stake` }],
             title: `A new text proposal for Cosmos`,
             type: `Text`,
             password: `1234567890`,

--- a/test/unit/specs/components/governance/TabParameters.spec.js
+++ b/test/unit/specs/components/governance/TabParameters.spec.js
@@ -9,8 +9,8 @@ describe(`TabParameters`, () => {
   let wrapper, store
   const { mount, localVue } = setup()
   localVue.use(Vuelidate)
-  localVue.directive(`tooltip`, () => {})
-  localVue.directive(`focus`, () => {})
+  localVue.directive(`tooltip`, () => { })
+  localVue.directive(`focus`, () => { })
 
   const $store = {
     commit: jest.fn(),
@@ -47,7 +47,7 @@ describe(`TabParameters`, () => {
   })
 
   it(`displays the minimum deposit`, () => {
-    expect(wrapper.vm.minimumDeposit).toEqual(`10 STAKEs`)
+    expect(wrapper.vm.minimumDeposit).toEqual(`100 STAKEs`)
   })
 
   it(`displays deposit period in days`, () => {

--- a/test/unit/specs/components/governance/__snapshots__/LiProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/LiProposal.spec.js.snap
@@ -45,7 +45,7 @@ exports[`LiProposal has the expected html structure 1`] = `
     class="li-proposal__value yes"
   >
     
-    500
+    5000
   
   </td>
    
@@ -53,7 +53,7 @@ exports[`LiProposal has the expected html structure 1`] = `
     class="li-proposal__value no"
   >
     
-    25
+    250
   
   </td>
    
@@ -61,7 +61,7 @@ exports[`LiProposal has the expected html structure 1`] = `
     class="li-proposal__value no_with_veto"
   >
     
-    10
+    100
   
   </td>
    
@@ -69,7 +69,7 @@ exports[`LiProposal has the expected html structure 1`] = `
     class="li-proposal__value abstain"
   >
     
-    56
+    560
   
   </td>
 </tr>

--- a/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
@@ -95,7 +95,7 @@ exports[`PageProposal has the expected html structure if user has signed in 1`] 
          
         <dd>
           
-            200 stake
+            2000 stake
           
         </dd>
       </dl>
@@ -302,7 +302,7 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
          
         <dd>
           
-            200 stake
+            2000 stake
           
         </dd>
       </dl>
@@ -315,7 +315,7 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
         </dt>
          
         <dd>
-          1000
+          10000
         </dd>
       </dl>
     </div>
@@ -335,7 +335,7 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
         </dt>
          
         <dd>
-          100 / 10%
+          1000 / 10%
         </dd>
       </dl>
        
@@ -347,7 +347,7 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
         </dt>
          
         <dd>
-          200 / 20%
+          2000 / 20%
         </dd>
       </dl>
        
@@ -360,7 +360,7 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
          
         <dd>
           
-            300 / 30%
+            3000 / 30%
           
         </dd>
       </dl>
@@ -373,7 +373,7 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
         </dt>
          
         <dd>
-          400 / 40%
+          4000 / 40%
         </dd>
       </dl>
     </div>

--- a/test/unit/specs/components/governance/__snapshots__/TabParameters.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/TabParameters.spec.js.snap
@@ -29,7 +29,7 @@ exports[`TabParameters has the expected html structure 1`] = `
            
           <dd>
             
-            10 STAKEs
+            100 STAKEs
           
           </dd>
         </dl>

--- a/test/unit/specs/components/governance/__snapshots__/TabProposals.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/TabProposals.spec.js.snap
@@ -143,7 +143,7 @@ exports[`TabProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    10
+    100
   
         </td>
          
@@ -151,7 +151,7 @@ exports[`TabProposals has the expected html structure 1`] = `
           class="li-proposal__value no"
         >
           
-    30
+    300
   
         </td>
          
@@ -159,7 +159,7 @@ exports[`TabProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    100
+    1000
   
         </td>
          
@@ -167,7 +167,7 @@ exports[`TabProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    20
+    200
   
         </td>
       </tr>
@@ -351,7 +351,7 @@ exports[`TabProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    500
+    5000
   
         </td>
          
@@ -359,7 +359,7 @@ exports[`TabProposals has the expected html structure 1`] = `
           class="li-proposal__value no"
         >
           
-    25
+    250
   
         </td>
          
@@ -367,7 +367,7 @@ exports[`TabProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    10
+    100
   
         </td>
          
@@ -375,7 +375,7 @@ exports[`TabProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    56
+    560
   
         </td>
       </tr>

--- a/test/unit/specs/components/governance/__snapshots__/TableProposals.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/TableProposals.spec.js.snap
@@ -143,7 +143,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    10
+    100
   
         </td>
          
@@ -151,7 +151,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no"
         >
           
-    30
+    300
   
         </td>
          
@@ -159,7 +159,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    100
+    1000
   
         </td>
          
@@ -167,7 +167,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    20
+    200
   
         </td>
       </tr>
@@ -351,7 +351,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    500
+    5000
   
         </td>
          
@@ -359,7 +359,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no"
         >
           
-    25
+    250
   
         </td>
          
@@ -367,7 +367,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    10
+    100
   
         </td>
          
@@ -375,7 +375,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    56
+    560
   
         </td>
       </tr>
@@ -527,7 +527,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value yes"
         >
           
-    10
+    100
   
         </td>
          
@@ -535,7 +535,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no"
         >
           
-    30
+    300
   
         </td>
          
@@ -543,7 +543,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    100
+    1000
   
         </td>
          
@@ -551,7 +551,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value abstain"
         >
           
-    20
+    200
   
         </td>
       </tr>
@@ -735,7 +735,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value yes"
         >
           
-    500
+    5000
   
         </td>
          
@@ -743,7 +743,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no"
         >
           
-    25
+    250
   
         </td>
          
@@ -751,7 +751,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    10
+    100
   
         </td>
          
@@ -759,7 +759,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value abstain"
         >
           
-    56
+    560
   
         </td>
       </tr>

--- a/test/unit/specs/components/network/__snapshots__/PageNetwork.spec.js.snap
+++ b/test/unit/specs/components/network/__snapshots__/PageNetwork.spec.js.snap
@@ -104,7 +104,7 @@ exports[`PageNetwork should display the network page with data and the blocks ta
               id="loose_tokens"
             >
               
-              0.0000010
+              0.0000100
             
             </dd>
           </dl>
@@ -124,7 +124,7 @@ exports[`PageNetwork should display the network page with data and the blocks ta
               id="bonded_tokens"
             >
               
-              0.0000125
+              0.0001250
             
             </dd>
           </dl>
@@ -288,7 +288,7 @@ exports[`PageNetwork should display the network page with the blocks table in a 
               id="loose_tokens"
             >
               
-              0.0000010
+              0.0000100
             
             </dd>
           </dl>
@@ -308,7 +308,7 @@ exports[`PageNetwork should display the network page with the blocks table in a 
               id="bonded_tokens"
             >
               
-              0.0000125
+              0.0001250
             
             </dd>
           </dl>

--- a/test/unit/specs/components/network/__snapshots__/PageNetwork.spec.js.snap
+++ b/test/unit/specs/components/network/__snapshots__/PageNetwork.spec.js.snap
@@ -104,7 +104,7 @@ exports[`PageNetwork should display the network page with data and the blocks ta
               id="loose_tokens"
             >
               
-              0.0000100
+              0.000010
             
             </dd>
           </dl>
@@ -124,7 +124,7 @@ exports[`PageNetwork should display the network page with data and the blocks ta
               id="bonded_tokens"
             >
               
-              0.0001250
+              0.000125
             
             </dd>
           </dl>
@@ -288,7 +288,7 @@ exports[`PageNetwork should display the network page with the blocks table in a 
               id="loose_tokens"
             >
               
-              0.0000100
+              0.000010
             
             </dd>
           </dl>
@@ -308,7 +308,7 @@ exports[`PageNetwork should display the network page with the blocks table in a 
               id="bonded_tokens"
             >
               
-              0.0001250
+              0.000125
             
             </dd>
           </dl>

--- a/test/unit/specs/components/staking/DelegationModal.spec.js
+++ b/test/unit/specs/components/staking/DelegationModal.spec.js
@@ -84,7 +84,7 @@ describe(`DelegationModal`, () => {
       })
 
       it(`if the user manually inputs a number greater than the balance`, () => {
-        wrapper.setData({ amount: 142 })
+        wrapper.setData({ amount: 1420 })
         expect(wrapper.vm.validateForm()).toBe(false)
       })
     })
@@ -119,7 +119,8 @@ describe(`DelegationModal`, () => {
           session,
           from,
           submitDelegation,
-          submitRedelegation },
+          submitRedelegation
+        },
         `local`, `1234567890`
       )
       expect(submitDelegation).toHaveBeenCalledWith(`local`, `1234567890`)
@@ -163,7 +164,7 @@ describe(`DelegationModal`, () => {
 
       expect($store.dispatch).toHaveBeenCalledWith(`submitDelegation`,
         {
-          amount: `500000000`,
+          amount: `50000000`,
           validator_address: validator.operator_address,
           password: `1234567890`,
           submitType: `local`
@@ -203,7 +204,7 @@ describe(`DelegationModal`, () => {
 
       expect($store.dispatch).toHaveBeenCalledWith(`submitRedelegation`,
         {
-          amount: `500000000`,
+          amount: `50000000`,
           validatorSrc: delegates.delegates[0],
           validatorDst: validator,
           password: `1234567890`,

--- a/test/unit/specs/components/staking/LiValidator.spec.js
+++ b/test/unit/specs/components/staking/LiValidator.spec.js
@@ -182,7 +182,7 @@ describe(`LiValidator`, () => {
       }
     }
 
-    expect(wrapper.find(`.li-validator__rewards`).html()).toContain(`123.0000…`)
+    expect(wrapper.find(`.li-validator__rewards`).html()).toContain(`1,230.0000…`)
   })
 
   it(`works if user is not signed in`, () => {

--- a/test/unit/specs/components/staking/PageValidator.spec.js
+++ b/test/unit/specs/components/staking/PageValidator.spec.js
@@ -200,7 +200,7 @@ describe(`PageValidator`, () => {
       const delegationString = PageValidator.computed.myDelegation.call(
         { bondDenom, myBond }
       )
-      expect(delegationString).toBe(`10.0000000 stake`)
+      expect(delegationString).toBe(`10.000000 stake`)
     })
 
     it(`when user doesn't have any delegations`, () => {
@@ -232,7 +232,7 @@ describe(`PageValidator`, () => {
       const rewardsString = PageValidator.computed.rewards.call(
         { session, bondDenom, distribution, validator }
       )
-      expect(rewardsString).toBe(`100.0000000 stake`)
+      expect(rewardsString).toBe(`100.000000 stake`)
     })
 
     it(`when validator rewards are 0`, () => {
@@ -246,7 +246,7 @@ describe(`PageValidator`, () => {
       const rewardsString = PageValidator.computed.rewards.call(
         { session, bondDenom, distribution, validator }
       )
-      expect(rewardsString).toBe(`0.0000000 stake`)
+      expect(rewardsString).toBe(`0.000000 stake`)
     })
 
     it(`when user doesn't have any delegations`, () => {

--- a/test/unit/specs/components/staking/PageValidator.spec.js
+++ b/test/unit/specs/components/staking/PageValidator.spec.js
@@ -232,7 +232,7 @@ describe(`PageValidator`, () => {
       const rewardsString = PageValidator.computed.rewards.call(
         { session, bondDenom, distribution, validator }
       )
-      expect(rewardsString).toBe(`10.0000000 stake`)
+      expect(rewardsString).toBe(`100.0000000 stake`)
     })
 
     it(`when validator rewards are 0`, () => {

--- a/test/unit/specs/components/staking/UndelegationModal.spec.js
+++ b/test/unit/specs/components/staking/UndelegationModal.spec.js
@@ -101,7 +101,7 @@ describe(`UndelegationModal`, () => {
 
       expect($store.dispatch).toHaveBeenCalledWith(`submitUnbondingDelegation`,
         {
-          amount: -42000000,
+          amount: -4200000,
           validator,
           submitType: `local`,
           password: `1234567890`

--- a/test/unit/specs/components/staking/__snapshots__/ModalWithdrawAllRewards.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/ModalWithdrawAllRewards.spec.js.snap
@@ -23,7 +23,7 @@ exports[`ModalWithdrawAllRewards should show the withdraw rewards modal 1`] = `
       id="amount"
       readonly="readonly"
       type="number"
-      value="1"
+      value="10"
     />
   </tm-form-group-stub>
 </action-modal-stub>

--- a/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
@@ -90,7 +90,7 @@ exports[`PageValidator shows a validator profile information errors signing info
             </dt>
              
             <dd>
-              0.0000000 STAKE
+              0.000000 STAKE
             </dd>
           </dl>
         </div>
@@ -417,7 +417,7 @@ exports[`PageValidator shows a validator profile information if user has signed 
             </dt>
              
             <dd>
-              0.0000000 STAKE
+              0.000000 STAKE
             </dd>
           </dl>
         </div>

--- a/test/unit/specs/components/transactions/LiStakeTransaction.spec.js
+++ b/test/unit/specs/components/transactions/LiStakeTransaction.spec.js
@@ -80,7 +80,7 @@ describe(`LiStakeTransaction`, () => {
       propsData.unbondingTime = Date.now() - 1000
       wrapper.setProps({ unbondingTime: Date.now() - 1000 })
       expect(wrapper.vm.$el).toMatchSnapshot()
-      expect(wrapper.text()).toContain(`10,000.0000000`)
+      expect(wrapper.text()).toContain(`10,000.000000`)
     })
 
     it(`should default to ended if no unbonding delegation is present`, () => {

--- a/test/unit/specs/components/transactions/LiStakeTransaction.spec.js
+++ b/test/unit/specs/components/transactions/LiStakeTransaction.spec.js
@@ -80,7 +80,7 @@ describe(`LiStakeTransaction`, () => {
       propsData.unbondingTime = Date.now() - 1000
       wrapper.setProps({ unbondingTime: Date.now() - 1000 })
       expect(wrapper.vm.$el).toMatchSnapshot()
-      expect(wrapper.text()).toContain(`1,000.00`)
+      expect(wrapper.text()).toContain(`10,000.0000000`)
     })
 
     it(`should default to ended if no unbonding delegation is present`, () => {

--- a/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
@@ -10,7 +10,7 @@ exports[`LiBankTransaction should show bank transaction when user hasn't signed 
     
       Sent 
     <b>
-      12,340.0000000
+      12,340.000000
     </b>
      
     <span>
@@ -44,7 +44,7 @@ exports[`LiBankTransaction should show incoming transactions 1`] = `
       Received 
       
     <b>
-      12,340.0000000
+      12,340.000000
     </b>
      
     <span>
@@ -72,7 +72,7 @@ exports[`LiBankTransaction should show outgoing transactions 1`] = `
       Sent 
       
     <b>
-      12,340.0000000
+      12,340.000000
     </b>
      
     <span>
@@ -101,7 +101,7 @@ exports[`LiBankTransaction should show outgoing transactions send to herself 1`]
       Sent 
       
     <b>
-      12,340.0000000
+      12,340.000000
     </b>
      
     <span>

--- a/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
@@ -10,7 +10,7 @@ exports[`LiBankTransaction should show bank transaction when user hasn't signed 
     
       Sent 
     <b>
-      1,234.0000000
+      12,340.0000000
     </b>
      
     <span>
@@ -44,7 +44,7 @@ exports[`LiBankTransaction should show incoming transactions 1`] = `
       Received 
       
     <b>
-      1,234.0000000
+      12,340.0000000
     </b>
      
     <span>
@@ -72,7 +72,7 @@ exports[`LiBankTransaction should show outgoing transactions 1`] = `
       Sent 
       
     <b>
-      1,234.0000000
+      12,340.0000000
     </b>
      
     <span>
@@ -101,7 +101,7 @@ exports[`LiBankTransaction should show outgoing transactions send to herself 1`]
       Sent 
       
     <b>
-      1,234.0000000
+      12,340.0000000
     </b>
      
     <span>

--- a/test/unit/specs/components/transactions/__snapshots__/LiGovTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiGovTransaction.spec.js.snap
@@ -11,7 +11,7 @@ exports[`LiGovTransaction deposits 1`] = `
       Deposit 
       
     <b>
-      100.0000000
+      1,000.0000000
     </b>
      
     <span>
@@ -45,7 +45,7 @@ exports[`LiGovTransaction proposals 1`] = `
       Submit text proposal 
       
     <b>
-      100.0000000
+      1,000.0000000
     </b>
      
     <span>

--- a/test/unit/specs/components/transactions/__snapshots__/LiGovTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiGovTransaction.spec.js.snap
@@ -11,7 +11,7 @@ exports[`LiGovTransaction deposits 1`] = `
       Deposit 
       
     <b>
-      1,000.0000000
+      1,000.000000
     </b>
      
     <span>
@@ -45,7 +45,7 @@ exports[`LiGovTransaction proposals 1`] = `
       Submit text proposal 
       
     <b>
-      1,000.0000000
+      1,000.000000
     </b>
      
     <span>

--- a/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
@@ -11,7 +11,7 @@ exports[`LiStakeTransaction create validator 1`] = `
       Create validator 
       
     <b>
-      1.0000000
+      1.000000
     </b>
      
     <span>
@@ -45,7 +45,7 @@ exports[`LiStakeTransaction delegations should show delegations 1`] = `
       Delegation 
       
     <b>
-      42,000.0000000
+      42,000.000000
     </b>
      
     <span>
@@ -101,7 +101,7 @@ exports[`LiStakeTransaction redelegations should show redelegations and calculat
       
     <b>
       
-        30.0000000
+        30.000000
       
     </b>
      
@@ -147,7 +147,7 @@ exports[`LiStakeTransaction unbonding delegations should default to ended if no 
       
     <b>
       
-        10,000.0000000
+        10,000.000000
       
     </b>
      
@@ -185,7 +185,7 @@ exports[`LiStakeTransaction unbonding delegations should show unbonding delegati
       
     <b>
       
-        10,000.0000000
+        10,000.000000
       
     </b>
      
@@ -223,7 +223,7 @@ exports[`LiStakeTransaction unbonding delegations should show unbondings and cal
       
     <b>
       
-        10,000.0000000
+        10,000.000000
       
     </b>
      

--- a/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
@@ -11,7 +11,7 @@ exports[`LiStakeTransaction create validator 1`] = `
       Create validator 
       
     <b>
-      0.1000000
+      1.0000000
     </b>
      
     <span>
@@ -45,7 +45,7 @@ exports[`LiStakeTransaction delegations should show delegations 1`] = `
       Delegation 
       
     <b>
-      4,200.0000000
+      42,000.0000000
     </b>
      
     <span>
@@ -101,7 +101,7 @@ exports[`LiStakeTransaction redelegations should show redelegations and calculat
       
     <b>
       
-        3.0000000
+        30.0000000
       
     </b>
      
@@ -147,7 +147,7 @@ exports[`LiStakeTransaction unbonding delegations should default to ended if no 
       
     <b>
       
-        1,000.0000000
+        10,000.0000000
       
     </b>
      
@@ -185,7 +185,7 @@ exports[`LiStakeTransaction unbonding delegations should show unbonding delegati
       
     <b>
       
-        1,000.0000000
+        10,000.0000000
       
     </b>
      
@@ -223,7 +223,7 @@ exports[`LiStakeTransaction unbonding delegations should show unbondings and cal
       
     <b>
       
-        1,000.0000000
+        10,000.0000000
       
     </b>
      

--- a/test/unit/specs/components/wallet/LiCoin.spec.js
+++ b/test/unit/specs/components/wallet/LiCoin.spec.js
@@ -20,7 +20,7 @@ describe(`LiCoin`, () => {
   })
 
   it(`should calculate the full amount of the coin`, () => {
-    expect(wrapper.vm.amount).toEqual(`1,000.0000000`)
+    expect(wrapper.vm.amount).toEqual(`10,000.0000000`)
   })
 
   it(`should capitalize the coin denomination`, () => {

--- a/test/unit/specs/components/wallet/LiCoin.spec.js
+++ b/test/unit/specs/components/wallet/LiCoin.spec.js
@@ -20,7 +20,7 @@ describe(`LiCoin`, () => {
   })
 
   it(`should calculate the full amount of the coin`, () => {
-    expect(wrapper.vm.amount).toEqual(`10,000.0000000`)
+    expect(wrapper.vm.amount).toEqual(`10,000.000000`)
   })
 
   it(`should capitalize the coin denomination`, () => {

--- a/test/unit/specs/components/wallet/__snapshots__/LiCoin.spec.js.snap
+++ b/test/unit/specs/components/wallet/__snapshots__/LiCoin.spec.js.snap
@@ -35,7 +35,7 @@ exports[`LiCoin has the expected html structure 1`] = `
         class="coin-amount"
       >
         
-        1,000.0000000
+        10,000.0000000
       
       </p>
     </div>

--- a/test/unit/specs/components/wallet/__snapshots__/LiCoin.spec.js.snap
+++ b/test/unit/specs/components/wallet/__snapshots__/LiCoin.spec.js.snap
@@ -35,7 +35,7 @@ exports[`LiCoin has the expected html structure 1`] = `
         class="coin-amount"
       >
         
-        10,000.0000000
+        10,000.000000
       
       </p>
     </div>

--- a/test/unit/specs/scripts/num.spec.js
+++ b/test/unit/specs/scripts/num.spec.js
@@ -2,7 +2,7 @@ import num from "renderer/scripts/num"
 
 describe(`number helper`, () => {
   it(`should format numbers showing many decimals`, () => {
-    expect(num.full(1001950.123456)).toBe(`1,001,950.1234560`)
+    expect(num.full(1001950.123456)).toBe(`1,001,950.123456`)
   })
 
   it(`should format numbers showing many decimals`, () => {


### PR DESCRIPTION
Closes #2273

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

conversion was using `10e6` instead of `1e6`

Thank you! 🚀

---

For contributor:

- [ ] Added entries in `PENDING.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
