### PR TITLE
Fabo/ changed to pending rewards

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -1,3 +1,4 @@
 ### Changed
 
 - [\#1337](https://github.com/cosmos/voyager/issues/1337) Updated modals tests acording to standard @fedekunze
+- Changed "Total Rewards" to "Pending Rewards" in the balance header @faboweb

--- a/PENDING.md
+++ b/PENDING.md
@@ -1,4 +1,4 @@
 ### Changed
 
 - [\#1337](https://github.com/cosmos/voyager/issues/1337) Updated modals tests acording to standard @fedekunze
-- Changed "Total Rewards" to "Pending Rewards" in the balance header @faboweb
+- [\#2328](https://github.com/cosmos/voyager/pull/2328) Changed "Total Rewards" to "Pending Rewards" in the balance header @faboweb

--- a/app/src/renderer/components/common/TmBalance.vue
+++ b/app/src/renderer/components/common/TmBalance.vue
@@ -13,7 +13,7 @@
         <h2>{{ unbondedAtoms }}</h2>
       </div>
       <div v-if="rewards" class="top-section">
-        <h3>Total Rewards</h3>
+        <h3>Pending Rewards</h3>
         <h2>{{ rewards }}</h2>
         <tm-btn
           id="withdraw-btn"

--- a/test/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
@@ -43,7 +43,7 @@ exports[`TmBalance has the expected html structure before adding props 1`] = `
       class="top-section"
     >
       <h3>
-        Total Rewards
+        Pending Rewards
       </h3>
        
       <h2>


### PR DESCRIPTION
Changed to "Pending Rewards" to be more correct until we have total rewards.

![image](https://user-images.githubusercontent.com/5869273/54765451-d5f42d00-4bf9-11e9-8b74-8c67d35bb878.png)

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added entries in `PENDING.md` with issue # and GitHub username
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
