### PR TITLE
Fabo/ fixed rewards not showing

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -6,3 +6,4 @@
 
 - [\#2330](https://github.com/cosmos/voyager/pull/2330) Fixed rewards not updating as expected @faboweb
 - [\#2330](https://github.com/cosmos/voyager/pull/2330) Fixed transactions not loading when refreshing on PageTransactions @faboweb
+- Fixed rewards not showing @faboweb

--- a/app/src/renderer/components/common/TmBalance.vue
+++ b/app/src/renderer/components/common/TmBalance.vue
@@ -2,14 +2,14 @@
   <div class="header-balance">
     <div class="top">
       <div class="total-atoms top-section">
-        <h3>Total {{ bondDenom }}</h3>
+        <h3>Total {{ num.viewDenom(bondDenom) }}</h3>
         <h2 class="total-atoms__value">
           {{ totalAtomsDisplay }}
         </h2>
         <short-bech32 :address="session.address || ''" />
       </div>
       <div v-if="unbondedAtoms" class="unbonded-atoms top-section">
-        <h3>Available {{ bondDenom }}</h3>
+        <h3>Available {{ num.viewDenom(bondDenom) }}</h3>
         <h2>{{ unbondedAtoms }}</h2>
       </div>
       <div v-if="rewards" class="top-section">

--- a/app/src/renderer/components/common/TmOnboarding.vue
+++ b/app/src/renderer/components/common/TmOnboarding.vue
@@ -49,6 +49,7 @@
 
 <script>
 import { mapGetters } from "vuex"
+import num from "scripts/num"
 import PerfectScrollbar from "perfect-scrollbar"
 import TmBarDiscrete from "common/TmBarDiscrete"
 import TmBtn from "common/TmBtn"
@@ -64,9 +65,11 @@ export default {
       const nodes = [
         `This is a quick tour of the primary features of Cosmos Voyager.`,
         `You can send and receive Cosmos tokens from anyone around the world.`,
-        `You can delegate your ${
+        `You can delegate your ${num.viewDenom(
           this.bondDenom
-        } to Cosmos Validators to earn even more ${this.bondDenom}.`,
+        )} to Cosmos Validators to earn even more ${num.viewDenom(
+          this.bondDenom
+        )}.`,
         `Through governance, you can vote on the future of the Cosmos Network.`,
         `Start using Voyager to explore the Cosmos Network!`
       ]

--- a/app/src/renderer/components/network/PageNetwork.vue
+++ b/app/src/renderer/components/network/PageNetwork.vue
@@ -43,7 +43,7 @@
         <div class="row">
           <div class="column">
             <dl class="info_dl">
-              <dt>Total Liquid {{ bondDenom }}</dt>
+              <dt>Total Liquid {{ num.viewDenom(bondDenom) }}</dt>
               <dd id="loose_tokens">
                 {{
                   pool.pool && pool.pool.not_bonded_tokens
@@ -55,7 +55,7 @@
           </div>
           <div class="column">
             <dl class="info_dl">
-              <dt>Total Delegated {{ bondDenom }}</dt>
+              <dt>Total Delegated {{ num.viewDenom(bondDenom) }}</dt>
               <dd id="bonded_tokens">
                 {{
                   pool.pool && pool.pool.bonded_tokens

--- a/app/src/renderer/components/staking/ModalWithdrawAllRewards.vue
+++ b/app/src/renderer/components/staking/ModalWithdrawAllRewards.vue
@@ -12,7 +12,7 @@
       field-id="amount"
       field-label="Amount"
     >
-      <span class="input-suffix">{{ bondDenom }}</span>
+      <span class="input-suffix">{{ num.viewDenom(bondDenom) }}</span>
       <tm-field
         id="amount"
         v-model="totalRewards"

--- a/app/src/renderer/components/staking/PageValidator.vue
+++ b/app/src/renderer/components/staking/PageValidator.vue
@@ -176,7 +176,7 @@
 import moment from "moment"
 import { calculateTokens } from "scripts/common"
 import { mapGetters } from "vuex"
-import { percent, pretty, atoms, full } from "scripts/num"
+import num, { percent, pretty, atoms, full } from "scripts/num"
 import TmBtn from "common/TmBtn"
 import { shortAddress, ratToBigNumber } from "scripts/common"
 import DelegationModal from "staking/DelegationModal"
@@ -233,7 +233,7 @@ export default {
       const totalBlocks = this.lastHeader.height
       const missedBlocks = this.validator.signing_info.missed_blocks_counter
       const signedBlocks = totalBlocks - missedBlocks
-      const uptime = (signedBlocks / totalBlocks) * 100
+      const uptime = signedBlocks / totalBlocks * 100
 
       return String(uptime).substring(0, 4) + `%`
     },
@@ -249,7 +249,7 @@ export default {
     myDelegation() {
       const { bondDenom, myBond } = this
       const myDelegation = full(myBond)
-      const myDelegationString = `${myDelegation} ${bondDenom}`
+      const myDelegationString = `${myDelegation} ${num.viewDenom(bondDenom)}`
       return Number(myBond) === 0 ? `--` : myDelegationString
     },
     powerRatio() {

--- a/app/src/renderer/components/staking/TabMyDelegations.vue
+++ b/app/src/renderer/components/staking/TabMyDelegations.vue
@@ -14,8 +14,8 @@
         No Active Delegations
       </div>
       <div slot="subtitle">
-        Looks like you haven't delegated any {{ bondDenom }}s yet. Head over to
-        the
+        Looks like you haven't delegated any {{ num.viewDenom(bondDenom) }}s
+        yet. Head over to the
         <router-link :to="{ name: 'Validators' }">
           validator list
         </router-link>

--- a/app/src/renderer/components/staking/TabStakingParameters.vue
+++ b/app/src/renderer/components/staking/TabStakingParameters.vue
@@ -29,7 +29,7 @@
             <dl class="info_dl">
               <dt>Current Staking Token</dt>
               <dd id="bond_denom">
-                {{ bondDenom ? bondDenom : `--` }}
+                {{ bondDenom ? num.viewDenom(bondDenom) : `--` }}
               </dd>
             </dl>
           </div>
@@ -53,6 +53,7 @@
 
 <script>
 import { mapGetters } from "vuex"
+import num from "scripts/num"
 import TmDataConnecting from "common/TmDataConnecting"
 import TmDataLoading from "common/TmDataLoading"
 export default {
@@ -62,6 +63,7 @@ export default {
     TmDataLoading
   },
   data: () => ({
+    num,
     paramsTooltips: {
       description: `Staking parameters define the high level settings for staking`,
       unbonding_time: `Time to complete an undelegation transaction and claim rewards`,

--- a/app/src/renderer/components/staking/TableValidators.vue
+++ b/app/src/renderer/components/staking/TableValidators.vue
@@ -100,9 +100,9 @@ export default {
         {
           title: `My Delegations`,
           value: `my_delegations`,
-          tooltip: `Number of ${
+          tooltip: `Number of ${num.viewDenom(
             this.bondDenom
-          } you have delegated to this validator`
+          )} you have delegated to this validator`
         },
         {
           title: `Rewards`,

--- a/app/src/renderer/components/transactions/LiDistributionTransaction.vue
+++ b/app/src/renderer/components/transactions/LiDistributionTransaction.vue
@@ -16,7 +16,13 @@
       <div slot="fees">
         Network Fee:&nbsp;
         <b>{{ convertedFees ? convertedFees.amount : full(0) }}</b>
-        <span>{{ convertedFees ? convertedFees.denom : bondingDenom }}s</span>
+        <span>
+          {{
+            convertedFees
+              ? convertedFees.denom
+              : num.viewDenom(bondingDenom)
+          }}s
+        </span>
       </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgSetWithdrawAddress`">
@@ -29,7 +35,13 @@
       <div slot="fees">
         Network Fee:&nbsp;
         <b>{{ convertedFees ? convertedFees.amount : full(0) }}</b>
-        <span>{{ convertedFees ? convertedFees.denom : bondingDenom }}s</span>
+        <span>
+          {{
+            convertedFees
+              ? convertedFees.denom
+              : num.viewDenom(bondingDenom)
+          }}s
+        </span>
       </div>
     </template>
     <template
@@ -46,7 +58,13 @@
       <div slot="fees">
         Network Fee:&nbsp;
         <b>{{ convertedFees ? convertedFees.amount : full(0) }}</b>
-        <span>{{ convertedFees ? convertedFees.denom : bondingDenom }}s</span>
+        <span>
+          {{
+            convertedFees
+              ? convertedFees.denom
+              : num.viewDenom(bondingDenom)
+          }}s
+        </span>
       </div>
     </template>
   </li-transaction>
@@ -96,7 +114,8 @@ export default {
   data: () => ({
     atoms,
     full,
-    pretty
+    pretty,
+    num
   }),
   computed: {
     convertedFees() {

--- a/app/src/renderer/components/transactions/LiStakeTransaction.vue
+++ b/app/src/renderer/components/transactions/LiStakeTransaction.vue
@@ -19,7 +19,13 @@
       <div slot="fees">
         Network Fee:&nbsp;
         <b>{{ convertedFees ? convertedFees.amount : full(0) }}</b>
-        <span>{{ convertedFees ? convertedFees.denom : bondingDenom }}s</span>
+        <span>
+          {{
+            convertedFees
+              ? convertedFees.denom
+              : num.viewDenom(bondingDenom)
+          }}s
+        </span>
       </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgEditValidator`">
@@ -35,7 +41,13 @@
       <div slot="fees">
         Network Fee:&nbsp;
         <b>{{ convertedFees ? convertedFees.amount : full(0) }}</b>
-        <span>{{ convertedFees ? convertedFees.denom : bondingDenom }}s</span>
+        <span>
+          {{
+            convertedFees
+              ? convertedFees.denom
+              : num.viewDenom(bondingDenom)
+          }}s
+        </span>
       </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgDelegate`">
@@ -53,7 +65,13 @@
       <div slot="fees">
         Network Fee:&nbsp;
         <b>{{ convertedFees ? convertedFees.amount : full(0) }}</b>
-        <span>{{ convertedFees ? convertedFees.denom : bondingDenom }}s</span>
+        <span>
+          {{
+            convertedFees
+              ? convertedFees.denom
+              : num.viewDenom(bondingDenom)
+          }}s
+        </span>
       </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgUndelegate`">
@@ -64,7 +82,7 @@
             calculatePrettifiedTokens(tx.validator_address, tx.shares_amount)
           }}
         </b>
-        <span>{{ bondingDenom }}s</span>
+        <span>{{ num.viewDenom(bondingDenom) }}s</span>
         <template v-if="timeDiff">
           <span class="tx-unbonding__time-diff">
             {{ timeDiff }}
@@ -80,7 +98,13 @@
       <div slot="fees">
         Network Fee:&nbsp;
         <b>{{ convertedFees ? convertedFees.amount : full(0) }}</b>
-        <span>{{ convertedFees ? convertedFees.denom : bondingDenom }}s</span>
+        <span>
+          {{
+            convertedFees
+              ? convertedFees.denom
+              : num.viewDenom(bondingDenom)
+          }}s
+        </span>
       </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgBeginRedelegate`">
@@ -94,7 +118,7 @@
             )
           }}
         </b>
-        <span>{{ bondingDenom }}s</span>
+        <span>{{ num.viewDenom(bondingDenom) }}s</span>
       </div>
       <div slot="details">
         From&nbsp;
@@ -109,7 +133,13 @@
       <div slot="fees">
         Network Fee:&nbsp;
         <b>{{ convertedFees ? convertedFees.amount : full(0) }}</b>
-        <span>{{ convertedFees ? convertedFees.denom : bondingDenom }}s</span>
+        <span>
+          {{
+            convertedFees
+              ? convertedFees.denom
+              : num.viewDenom(bondingDenom)
+          }}s
+        </span>
       </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgUnjail`">
@@ -125,7 +155,13 @@
       <div slot="fees">
         Network Fee:&nbsp;
         <b>{{ convertedFees ? convertedFees.amount : full(0) }}</b>
-        <span>{{ convertedFees ? convertedFees.denom : bondingDenom }}s</span>
+        <span>
+          {{
+            convertedFees
+              ? convertedFees.denom
+              : num.viewDenom(bondingDenom)
+          }}s
+        </span>
       </div>
     </template>
   </li-transaction>
@@ -184,7 +220,8 @@ export default {
   },
   data: () => ({
     atoms,
-    full
+    full,
+    num
   }),
   computed: {
     timeDiff() {

--- a/app/src/renderer/vuex/getters.js
+++ b/app/src/renderer/vuex/getters.js
@@ -1,6 +1,5 @@
 import BN from "bignumber.js"
 import { calculateTokens } from "scripts/common"
-import num from "scripts/num"
 
 // ui
 export const filters = state => state.filters
@@ -85,7 +84,7 @@ export const pool = state => state.pool
 export const stakingParameters = state => state.stakingParameters
 export const bondDenom = getters =>
   getters.stakingParameters.parameters &&
-  num.viewDenom(getters.stakingParameters.parameters.bond_denom || `uatom`)
+  getters.stakingParameters.parameters.bond_denom || `uatom`
 
 // governance
 export const proposals = state => state.proposals

--- a/test/unit/specs/components/staking/__snapshots__/TabMyDelegations.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/TabMyDelegations.spec.js.snap
@@ -13,8 +13,8 @@ exports[`Component: TabMyDelegations view should show a message if not staked ye
      
     <div>
       
-      Looks like you haven't delegated any atoms yet. Head over to
-      the
+      Looks like you haven't delegated any atoms
+      yet. Head over to the
       
       <router-link-stub
         to="[object Object]"
@@ -58,8 +58,8 @@ exports[`Component: TabMyDelegations view should show unbonding validators and t
      
     <div>
       
-      Looks like you haven't delegated any atoms yet. Head over to
-      the
+      Looks like you haven't delegated any atoms
+      yet. Head over to the
       
       <router-link-stub
         to="[object Object]"

--- a/test/unit/specs/components/staking/__snapshots__/TabMyDelegations.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/TabMyDelegations.spec.js.snap
@@ -13,7 +13,7 @@ exports[`Component: TabMyDelegations view should show a message if not staked ye
      
     <div>
       
-      Looks like you haven't delegated any uatoms yet. Head over to
+      Looks like you haven't delegated any atoms yet. Head over to
       the
       
       <router-link-stub
@@ -58,7 +58,7 @@ exports[`Component: TabMyDelegations view should show unbonding validators and t
      
     <div>
       
-      Looks like you haven't delegated any uatoms yet. Head over to
+      Looks like you haven't delegated any atoms yet. Head over to
       the
       
       <router-link-stub

--- a/test/unit/specs/components/transactions/__snapshots__/LiDistributionTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiDistributionTransaction.spec.js.snap
@@ -66,7 +66,7 @@ exports[`LiDistributionTransaction transaction without fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
   </div>
 </li-transaction-stub>

--- a/test/unit/specs/components/transactions/__snapshots__/LiDistributionTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiDistributionTransaction.spec.js.snap
@@ -27,7 +27,9 @@ exports[`LiDistributionTransaction set withdraw address 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -66,7 +68,9 @@ exports[`LiDistributionTransaction transaction without fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -105,7 +109,9 @@ exports[`LiDistributionTransaction withdraw delegation rewards 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -144,7 +150,9 @@ exports[`LiDistributionTransaction withdraw validator commission 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>

--- a/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
@@ -41,7 +41,9 @@ exports[`LiStakeTransaction create validator with fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -88,7 +90,9 @@ exports[`LiStakeTransaction create validator without fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -135,7 +139,9 @@ exports[`LiStakeTransaction delegations with fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -182,7 +188,9 @@ exports[`LiStakeTransaction delegations without fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -222,7 +230,9 @@ exports[`LiStakeTransaction edit validator with fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -262,7 +272,9 @@ exports[`LiStakeTransaction edit validator without fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -321,7 +333,9 @@ exports[`LiStakeTransaction redelegations with fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -380,7 +394,9 @@ exports[`LiStakeTransaction redelegations without fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -431,7 +447,9 @@ exports[`LiStakeTransaction unbonding delegations should default to ended if no 
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -482,7 +500,9 @@ exports[`LiStakeTransaction unbonding delegations should show unbonding delegati
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -539,7 +559,9 @@ exports[`LiStakeTransaction unbonding delegations with fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -590,7 +612,9 @@ exports[`LiStakeTransaction unbonding delegations without fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -630,7 +654,9 @@ exports[`LiStakeTransaction unjail with fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>
@@ -670,7 +696,9 @@ exports[`LiStakeTransaction unjail without fees 1`] = `
     </b>
      
     <span>
-      atoms
+      
+        atoms
+      
     </span>
   </div>
 </li-transaction-stub>

--- a/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
@@ -88,7 +88,7 @@ exports[`LiStakeTransaction create validator without fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
   </div>
 </li-transaction-stub>
@@ -182,7 +182,7 @@ exports[`LiStakeTransaction delegations without fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
   </div>
 </li-transaction-stub>
@@ -262,7 +262,7 @@ exports[`LiStakeTransaction edit validator without fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
   </div>
 </li-transaction-stub>
@@ -285,7 +285,7 @@ exports[`LiStakeTransaction redelegations with fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
   </div>
    
@@ -344,7 +344,7 @@ exports[`LiStakeTransaction redelegations without fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
   </div>
    
@@ -380,7 +380,7 @@ exports[`LiStakeTransaction redelegations without fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
   </div>
 </li-transaction-stub>
@@ -403,7 +403,7 @@ exports[`LiStakeTransaction unbonding delegations should default to ended if no 
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
      
     <!---->
@@ -454,7 +454,7 @@ exports[`LiStakeTransaction unbonding delegations should show unbonding delegati
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
      
     <!---->
@@ -505,7 +505,7 @@ exports[`LiStakeTransaction unbonding delegations with fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
      
     <span
@@ -562,7 +562,7 @@ exports[`LiStakeTransaction unbonding delegations without fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
      
     <!---->
@@ -590,7 +590,7 @@ exports[`LiStakeTransaction unbonding delegations without fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
   </div>
 </li-transaction-stub>
@@ -670,7 +670,7 @@ exports[`LiStakeTransaction unjail without fees 1`] = `
     </b>
      
     <span>
-      uatoms
+      atoms
     </span>
   </div>
 </li-transaction-stub>


### PR DESCRIPTION
The rewards were always 0 as we were displaying user owned `atoms` instead of `uatoms`.